### PR TITLE
efivar-native: fix build failures on Fedora 24

### DIFF
--- a/recipes-support/efivar/efivar/Multiple-fixes-for-compilation-with-gcc-6.patch
+++ b/recipes-support/efivar/efivar/Multiple-fixes-for-compilation-with-gcc-6.patch
@@ -1,0 +1,359 @@
+From c82b13556ae142cec420258b8563f0dabb3dad83 Mon Sep 17 00:00:00 2001
+From: Steve McIntyre <steve@einval.com>
+Date: Wed, 20 Jan 2016 17:44:28 +0000
+Subject: [PATCH] Multiple fixes for compilation with gcc 6
+
+Multiple instances of non-NULL sanity checks against function
+arguments declared as __attribute__((__nonnull__)); gcc 6 now triggers
+warnings on these.
+
+dp.c: Remove Unused variable end_instance
+
+linux.c: Fix warnings about dereferencing type-punned pointers: switch
+from char * to uint8_t * in various places
+
+Signed-off-by: Steve McIntyre <steve@einval.com>
+Signed-off-by: Lans Zhang <jia.zhang@windriver.com>
+---
+ src/creator.c |  5 -----
+ src/dp-acpi.c |  5 -----
+ src/dp.c      |  5 -----
+ src/export.c  | 49 +------------------------------------------------
+ src/guid.c    |  3 ---
+ src/linux.c   | 10 +++++-----
+ src/loadopt.c | 22 +++-------------------
+ src/ucs2.h    |  2 +-
+ 8 files changed, 10 insertions(+), 91 deletions(-)
+
+diff --git a/src/creator.c b/src/creator.c
+index c33b935..41248dd 100644
+--- a/src/creator.c
++++ b/src/creator.c
+@@ -49,11 +49,6 @@ find_file(const char * const filepath, char **devicep, char **relpathp)
+ 	char linkbuf[PATH_MAX+1] = "";
+ 	ssize_t linklen = 0;
+ 
+-	if (!filepath || !devicep || !relpathp) {
+-		errno = EINVAL;
+-		return -1;
+-	}
+-
+ 	linklen = strlen(filepath);
+ 	if (linklen > PATH_MAX) {
+ 		errno = ENAMETOOLONG;
+diff --git a/src/dp-acpi.c b/src/dp-acpi.c
+index c266498..5cf755b 100644
+--- a/src/dp-acpi.c
++++ b/src/dp-acpi.c
+@@ -189,11 +189,6 @@ efidp_make_acpi_hid_ex(uint8_t *buf, ssize_t size,
+ 	ssize_t req;
+ 	ssize_t sz;
+ 
+-	if (!hidstr || !uidstr || !cidstr) {
+-		errno = EINVAL;
+-		return -1;
+-	}
+-
+ 	req = sizeof (*acpi_hid) + 3 +
+ 		strlen(hidstr) + strlen(uidstr) + strlen(cidstr);
+ 	sz = efidp_make_generic(buf, size, EFIDP_ACPI_TYPE, EFIDP_ACPI_HID_EX,
+diff --git a/src/dp.c b/src/dp.c
+index b839a9b..62a036b 100644
+--- a/src/dp.c
++++ b/src/dp.c
+@@ -28,11 +28,6 @@ static const efidp_header end_entire = {
+ 	.subtype = EFIDP_END_ENTIRE,
+ 	.length = 4
+ };
+-static const efidp_header end_instance = {
+-	.type = EFIDP_END_TYPE,
+-	.subtype = EFIDP_END_INSTANCE,
+-	.length = 4
+-};
+ 
+ static inline void *
+ efidp_data_address(const_efidp dp)
+diff --git a/src/export.c b/src/export.c
+index 2fa40d6..b706664 100644
+--- a/src/export.c
++++ b/src/export.c
+@@ -68,9 +68,6 @@ efi_variable_import(uint8_t *data, size_t size, efi_variable_t **var_out)
+ 	if (size <= min)
+ 		return -1;
+ 
+-	if (!var_out)
+-		return -1;
+-
+ 	uint8_t *ptr = data;
+ 	uint32_t magic = EFIVAR_MAGIC;
+ 	if (memcmp(data, &magic, sizeof (uint32_t)) ||
+@@ -149,10 +146,6 @@ __attribute__((__nonnull__ (1)))
+ __attribute__((__visibility__ ("default")))
+ efi_variable_export(efi_variable_t *var, uint8_t *data, size_t size)
+ {
+-	if (!var) {
+-		errno = EINVAL;
+-		return -1;
+-	}
+ 	size_t name_len = strlen(var->name);
+ 
+ 	size_t needed = sizeof (uint32_t)		/* magic */
+@@ -248,11 +241,6 @@ __attribute__((__nonnull__ (1, 2)))
+ __attribute__((__visibility__ ("default")))
+ efi_variable_set_name(efi_variable_t *var, char *name)
+ {
+-	if (!var || !name) {
+-		errno = EINVAL;
+-		return -1;
+-	}
+-
+ 	var->name = name;
+ 	return 0;
+ }
+@@ -267,11 +255,6 @@ __attribute__((__visibility__ ("default")))
+ #endif
+ efi_variable_get_name(efi_variable_t *var)
+ {
+-	if (!var) {
+-		errno = EINVAL;
+-		return NULL;
+-	}
+-
+ 	if (!var->name) {
+ 		errno = ENOENT;
+ 	} else {
+@@ -285,11 +268,6 @@ __attribute__((__nonnull__ (1, 2)))
+ __attribute__((__visibility__ ("default")))
+ efi_variable_set_guid(efi_variable_t *var, efi_guid_t *guid)
+ {
+-	if (!var || !guid) {
+-		errno = EINVAL;
+-		return -1;
+-	}
+-
+ 	var->guid = guid;
+ 	return 0;
+ }
+@@ -299,11 +277,6 @@ __attribute__((__nonnull__ (1, 2)))
+ __attribute__((__visibility__ ("default")))
+ efi_variable_get_guid(efi_variable_t *var, efi_guid_t **guid)
+ {
+-	if (!var || !guid) {
+-		errno = EINVAL;
+-		return -1;
+-	}
+-
+ 	if (!var->guid) {
+ 		errno = ENOENT;
+ 		return -1;
+@@ -318,7 +291,7 @@ __attribute__((__nonnull__ (1, 2)))
+ __attribute__((__visibility__ ("default")))
+ efi_variable_set_data(efi_variable_t *var, uint8_t *data, size_t size)
+ {
+-	if (!var || !data || !size) {
++	if (!size) {
+ 		errno = EINVAL;
+ 		return -1;
+ 	}
+@@ -333,11 +306,6 @@ __attribute__((__nonnull__ (1, 2, 3)))
+ __attribute__((__visibility__ ("default")))
+ efi_variable_get_data(efi_variable_t *var, uint8_t **data, size_t *size)
+ {
+-	if (!var || !data || !size) {
+-		errno = EINVAL;
+-		return -1;
+-	}
+-
+ 	if (var->data || !var->data_size) {
+ 		errno = ENOENT;
+ 		return -1;
+@@ -353,11 +321,6 @@ __attribute__((__nonnull__ (1)))
+ __attribute__((__visibility__ ("default")))
+ efi_variable_set_attributes(efi_variable_t *var, uint64_t attrs)
+ {
+-	if (!var) {
+-		errno = -EINVAL;
+-		return -1;
+-	}
+-
+ 	var->attrs = attrs;
+ 	return 0;
+ }
+@@ -367,11 +330,6 @@ __attribute__((__nonnull__ (1, 2)))
+ __attribute__((__visibility__ ("default")))
+ efi_variable_get_attributes(efi_variable_t *var, uint64_t *attrs)
+ {
+-	if (!var || !attrs) {
+-		errno = -EINVAL;
+-		return -1;
+-	}
+-
+ 	if (var->attrs == ATTRS_UNSET) {
+ 		errno = ENOENT;
+ 		return -1;
+@@ -386,11 +344,6 @@ __attribute__((__nonnull__ (1)))
+ __attribute__((__visibility__ ("default")))
+ efi_variable_realize(efi_variable_t *var)
+ {
+-	if (!var) {
+-		errno = -EINVAL;
+-		return -1;
+-	}
+-
+ 	if (!var->name || !var->data || !var->data_size ||
+ 			var->attrs == ATTRS_UNSET) {
+ 		errno = -EINVAL;
+diff --git a/src/guid.c b/src/guid.c
+index 25c28a7..f438917 100644
+--- a/src/guid.c
++++ b/src/guid.c
+@@ -218,9 +218,6 @@ efi_name_to_guid(const char *name, efi_guid_t *guid)
+ 	size_t nmemb = (end - start) / sizeof (efi_well_known_names);
+ 	size_t namelen;
+ 
+-	if (!name || !guid)
+-		return -1;
+-
+ 	namelen = strnlen(name, 39);
+ 	struct guidname key;
+ 	memset(&key, '\0', sizeof (key));
+diff --git a/src/linux.c b/src/linux.c
+index 3ebce7a..b618cfd 100644
+--- a/src/linux.c
++++ b/src/linux.c
+@@ -133,7 +133,7 @@ get_partition_number(const char *devpath)
+ 	int rc;
+ 	unsigned int maj, min;
+ 	char *linkbuf;
+-	char *partbuf;
++	uint8_t *partbuf;
+ 	int ret = -1;
+ 
+ 	rc = stat(devpath, &statbuf);
+@@ -156,7 +156,7 @@ get_partition_number(const char *devpath)
+ 	if (rc < 0)
+ 		return -1;
+ 
+-	rc = sscanf(partbuf, "%d\n", &ret);
++	rc = sscanf((char *)partbuf, "%d\n", &ret);
+ 	if (rc != 1)
+ 		return -1;
+ 	return ret;
+@@ -353,7 +353,7 @@ sysfs_parse_sas(uint8_t *buf, ssize_t size, ssize_t *off,
+ {
+ 	int rc;
+ 	int psz = 0;
+-	char *filebuf = NULL;
++	uint8_t *filebuf = NULL;
+ 	uint64_t sas_address;
+ 
+ 	*poff = 0;
+@@ -447,7 +447,7 @@ sysfs_parse_sas(uint8_t *buf, ssize_t size, ssize_t *off,
+ 	if (rc < 0)
+ 		return -1;
+ 
+-	rc = sscanf(filebuf, "%"PRIx64, &sas_address);
++	rc = sscanf((char *)filebuf, "%"PRIx64, &sas_address);
+ 	if (rc != 1)
+ 		return -1;
+ 
+@@ -490,7 +490,7 @@ make_pci_path(uint8_t *buf, ssize_t size, char *pathstr, ssize_t *pathoff)
+ 		return -1;
+ 	poff += psz;
+ 
+-	char *fbuf = NULL;
++	uint8_t *fbuf = NULL;
+ 	rc = read_sysfs_file(&fbuf,
+ 			     "/sys/devices/pci%04x:%02x/firmware_node/hid",
+ 			     root_domain, root_bus);
+diff --git a/src/loadopt.c b/src/loadopt.c
+index acaa50c..9ee727e 100644
+--- a/src/loadopt.c
++++ b/src/loadopt.c
+@@ -36,11 +36,6 @@ efi_loadopt_create(uint8_t *buf, ssize_t size, uint32_t attributes,
+ 		   efidp dp, ssize_t dp_size, unsigned char *description,
+ 		   uint8_t *optional_data, size_t optional_data_size)
+ {
+-	if (!description) {
+-		errno = EINVAL;
+-		return -1;
+-	}
+-
+ 	ssize_t desc_len = utf8len((uint8_t *)description, 1024) * 2 + 2;
+ 	ssize_t sz = sizeof (attributes)
+ 		     + sizeof (uint16_t) + desc_len
+@@ -90,9 +85,6 @@ efi_loadopt_optional_data_size(efi_load_option *opt, size_t size)
+ 	size_t sz;
+ 	uint8_t *p;
+ 
+-	if (!opt)
+-		return -1;
+-
+ 	if (size < sizeof(*opt))
+ 		return -1;
+ 	size -= sizeof(*opt);
+@@ -162,10 +154,6 @@ __attribute__((__visibility__ ("default")))
+ efi_loadopt_path(efi_load_option *opt)
+ {
+ 	char *p = (char *)opt;
+-	if (!opt) {
+-		errno = EINVAL;
+-		return NULL;
+-	}
+ 	efidp dp = (efidp)(p + sizeof (opt->attributes)
+ 		   + sizeof (opt->file_path_list_length)
+ 		   + ucs2size(opt->description, -1));
+@@ -179,10 +167,6 @@ efi_loadopt_optional_data(efi_load_option *opt, size_t opt_size,
+ 			  unsigned char **datap, size_t *len)
+ {
+ 	unsigned char *p = (unsigned char *)opt;
+-	if (!opt || !datap) {
+-		errno = EINVAL;
+-		return -1;
+-	}
+ 	*datap = (unsigned char *)(p + sizeof (opt->attributes)
+ 		   + sizeof (opt->file_path_list_length)
+ 		   + ucs2size(opt->description, -1)
+@@ -203,7 +187,7 @@ efi_loadopt_args_from_file(uint8_t *buf, ssize_t size, char *filename)
+ 	int saved_errno;
+ 	FILE *f;
+ 
+-	if (!filename || (!buf && size > 0)) {
++	if (!buf && size > 0) {
+ 		errno = -EINVAL;
+ 		return -1;
+ 	}
+@@ -241,7 +225,7 @@ __attribute__((__visibility__ ("default")))
+ efi_loadopt_args_as_utf8(uint8_t *buf, ssize_t size, char *utf8)
+ {
+ 	ssize_t req;
+-	if (!utf8 || (!buf && size > 0)) {
++	if (!buf && size > 0) {
+ 		errno = EINVAL;
+ 		return -1;
+ 	}
+@@ -268,7 +252,7 @@ __attribute__((__visibility__ ("default")))
+ efi_loadopt_args_as_ucs2(uint16_t *buf, ssize_t size, uint8_t *utf8)
+ {
+ 	ssize_t req;
+-	if (!utf8 || (!buf && size > 0)) {
++	if (!buf && size > 0) {
+ 		errno = EINVAL;
+ 		return -1;
+ 	}
+diff --git a/src/ucs2.h b/src/ucs2.h
+index 1b1a84c..b73ce90 100644
+--- a/src/ucs2.h
++++ b/src/ucs2.h
+@@ -120,7 +120,7 @@ utf8_to_ucs2(uint16_t *ucs2, ssize_t size, int terminate, uint8_t *utf8)
+ 	ssize_t req;
+ 	ssize_t i, j;
+ 
+-	if (!utf8 || (!ucs2 && size > 0)) {
++	if (!ucs2 && size > 0) {
+ 		errno = EINVAL;
+ 		return -1;
+ 	}
+-- 
+2.7.4
+

--- a/recipes-support/efivar/efivar/Workaround-rename-of-linux-nvme.h.patch
+++ b/recipes-support/efivar/efivar/Workaround-rename-of-linux-nvme.h.patch
@@ -1,0 +1,31 @@
+From 3a0ae7189fe96355d64dc2daf91cf85282773c66 Mon Sep 17 00:00:00 2001
+From: Mike Gilbert <floppym@gentoo.org>
+Date: Thu, 14 Jan 2016 17:02:31 -0500
+Subject: [PATCH] Workaround rename of linux/nvme.h
+
+Bug: https://bugs.gentoo.org/571548
+Signed-off-by: Lans Zhang <jia.zhang@windriver.com>
+---
+ src/linux.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/linux.c b/src/linux.c
+index b618cfd..9388cd3 100644
+--- a/src/linux.c
++++ b/src/linux.c
+@@ -22,7 +22,12 @@
+ #include <inttypes.h>
+ #include <limits.h>
+ #include <linux/ethtool.h>
++#include <linux/version.h>
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0)
++#include <linux/nvme_ioctl.h>
++#else
+ #include <linux/nvme.h>
++#endif
+ #include <linux/sockios.h>
+ #include <net/if.h>
+ #include <scsi/scsi.h>
+-- 
+2.7.4
+

--- a/recipes-support/efivar/efivar_0.21.bbappend
+++ b/recipes-support/efivar/efivar_0.21.bbappend
@@ -7,6 +7,8 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/efivar:"
 SRC_URI += "\
     file://Allow-to-override-the-pkg-config-from-the-external.patch \
     file://efivar-fix-build-failure-due-to-removing-std-gnu11.patch \
+    file://Multiple-fixes-for-compilation-with-gcc-6.patch \
+    file://Workaround-rename-of-linux-nvme.h.patch \
 "
 
 # In dp.h, 'for' loop initial declarations are used


### PR DESCRIPTION
The patches ported from upstream resolve the following build failures:

| guid.c: In function 'efi_name_to_guid':
| guid.c:215:6: error: nonnull argument 'name' compared to NULL
[-Werror=nonnull-compare]
|   if (!name || !guid)
|       ^~~~~
| guid.c:215:15: error: nonnull argument 'guid' compared to NULL
[-Werror=nonnull-compare]
|   if (!name || !guid)
|                ^~~~~

and

| linux.c:25:24: fatal error: linux/nvme.h: No such file or directory
|  #include <linux/nvme.h>
|                         ^
| compilation terminated.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>