### PR TITLE
storage-encryption: support data partition encryption

### DIFF
--- a/recipes-base/packagegroups/packagegroup-storage-encryption.bb
+++ b/recipes-base/packagegroups/packagegroup-storage-encryption.bb
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2016 Wind River Systems Inc.
+#
+
+include packagegroup-storage-encryption.inc
+
+DESCRIPTION = "The storage-encryption packages for wr-secure."
+
+# Install the minimal stuffs only for the linux rootfs.
+# The common packages shared between initramfs and rootfs
+# are listed in the .inc.
+# @util-linux: fdisk
+# @parted: parted
+# @rng-tools: rngd
+RDEPENDS_${PN} += " \
+    util-linux-fdisk \
+    parted \
+    rng-tools \
+"
+
+RRECOMMENDS_${PN} += "kernel-module-tpm-rng"

--- a/recipes-base/packagegroups/packagegroup-storage-encryption.inc
+++ b/recipes-base/packagegroups/packagegroup-storage-encryption.inc
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2016 Wind River Systems Inc.
+#
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690 \
+                    file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+ALLOW_EMPTY_${PN} = "1"
+ALLOW_EMPTY_${PN}-net = "1"
+
+# Install the minimal stuffs for the common uses between initramfs
+# and linux rootfs.
+# @util-linux: mount, umount
+# @cryptsetup: cryptsetup
+# @cryptfs-tpm: tpm_gen_dmcrypt_key, tpm_unwrap_dmcrypt_key 
+# @kmod: modprobe
+# @coreutils: cat, mkdir, mknod, cp, rm
+# @trousers: tcsd
+RDEPENDS_${PN} = " \
+    util-linux-mount \
+    util-linux-umount \
+    cryptsetup \
+    kmod \
+    coreutils \
+    libtss2 \
+    libtctidevice \
+    libtctisocket \
+"
+
+RRECOMMENDS_${PN} = "kernel-module-tpm-tis"

--- a/recipes-tpm/cryptfs-tpm2/cryptfs-tpm2_git.bb
+++ b/recipes-tpm/cryptfs-tpm2/cryptfs-tpm2_git.bb
@@ -1,0 +1,47 @@
+SUMMARY = "This project provides with an implementation \
+for storing/restoring a passphrase with TPM 2.0"
+DESCRIPTION = " \
+This project provides with an implementation for \
+storing/restoring a passphrase with TPM 2.0. The passphrase \
+and its associated primary key are automatically created by \
+RNG engine in TPM. In order to avoid saving the context file, \
+the created passphrase and primary key are always persistent \
+in TPM. \
+"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=af9aa760caa1532b4f5c9874d4e8c753"
+
+SRC_URI = " \
+    git://github.com/WindRiver-OpenSourceLabs/cryptfs-tpm2.git \
+"
+SRCREV = "cd8f07756c0322b22685d30175d0efeb474cf0fe"
+PV = "0.2.0+git${SRCPV}"
+
+DEPENDS += "tpm2.0-tss"
+RDEPENDS_${PN} += "libtss2 libtctisocket"
+
+PARALLEL_MAKE = ""
+
+S = "${WORKDIR}/git"
+
+EXTRA_OEMAKE = " \
+    prefix="${prefix}" \
+    sbindir="${sbindir}" \
+    libdir="${libdir}" \
+    includedir="${includedir}" \
+    tpm2_tss_includedir="${STAGING_LIBDIR}" \
+    tpm2_tss_libdir="${STAGING_INCDIR}" \
+    CC="${CC}" \
+    EXTRA_CFLAGS="${CFLAGS}" \
+    EXTRA_LDFLAGS="${LDFLAGS}" \
+"
+
+do_install() {
+    oe_runmake install DESTDIR="${D}"
+}
+
+FILES_${PN} = "\
+    ${sbindir} \
+    ${libdir} \
+"

--- a/templates/feature/storage-encryption/README
+++ b/templates/feature/storage-encryption/README
@@ -1,0 +1,258 @@
+Overview
+========
+
+This feature provides secure storage for application data. Some applications
+need secure storage for sensitive data which must not be accessible to another
+device. For example, only an application with the right signature can update
+the data on an encrypted SD card. If you move that SD card to another device,
+the data cannot be either read or updated. One application of this capability
+is a POS application. The application keeps tax information in secure storage
+that cannot be modified by another device.
+
+This feature gives 2 types of granularity for storage encryption. Data volume
+encryption allows the user to create encryption partition with a passphrase
+typed by the end user. Root filesystem encryption enables the data encryption on
+the entire rootfs except the boot partition.
+
+Both types of storage encryption are based on device-mapper crypt target,
+which provides transparent encryption of block devices using the kernel crypto
+API. Additionally, the utility cryptsetup is used to conveniently setup disk
+encryption based on device-mapper crypt target.
+
+Data Volume Encryption
+======================
+
+Use case 1: manual operation
+----------------------------
+- Create the LUKS partition
+# cryptsetup --type luks --cipher aes-xts-plain --hash sha256 \
+      --use-random luksFormat /dev/$dev
+where $dev is the device node of the partition to be encrypted.
+
+This command initializes a LUKS partition and promots to input an initial
+passphrase used to encrypt the data. Don't disclose the passphrase used for
+product.
+
+- Open the LUKS partition
+# cryptsetup luksOpen /dev/$dev $name
+
+This command opens the LUKS device $dev and sets up a mapping $name after
+successful verification of the supplied passphrase typed interactively. From
+now on, the data written to /dev/mapper/$name is encrypted and the data
+read back from /dev/mapper/$name is decrypted.
+
+- Create the filesystem/volume on the LUKS partition
+The user can run any available filesytem formatting program on
+/dev/mapper/$name to create the filesytem/volume with the data encryption.
+
+- Close the LUKS partition
+# cryptsetup luksClose $name
+
+This command removes the existing mapping $name and wipes the key from kernel
+memory.
+
+To access the encryped partition, follow the instruction "Open the LUKS partition"
+and then manually mount /dev/mapper/$name to a mount point.
+
+Use case 2: luks-setup.sh
+-------------------------
+Basically this script wraps the manual instructions above.
+
+In runtime, for example, create LUKS partition on /dev/sdb1 with the
+name "my_luks_part":
+# luks-setup.sh -d /dev/sdb1 -n my_luks_name
+
+Next refer to "Create the filesystem/volume on the LUKS partition" to manually
+create the filesystem/volume.
+
+Root Filesystem Encryption
+==========================
+
+This enables the data encryption on the rootfs without the need of a human
+entering an user passphrase. Therefore, it is required to employ an initramfs
+where the unique identity from the platform is collected from the devices on
+the platform and used to unlock the root filesystem encryption. Meanwhile, use
+TPM to protect the user passphrase for volume decryption to avoid disclosing
+the user passphrase. If the TPM chip is not detected, the end user will be
+prompted to type the user passphrase.
+
+Note:
+1. TPM 2.0 is validated and officially supported. TPM 1.2 is not supported.
+2. Due to the use of TPM state to seal the passphrase, the following procedure
+must be used on the same device that the filesystem will be deployed on. The
+resulting filesystem cannot be used on any other device.
+3. The non-default seal secret is supported to provide extra protection, and it
+is user configurable. Modify the value of CRYPTFS_TPM2_PRIMARY_KEY_SECRET and
+CRYPTFS_TPM2_PASSPHRASE_SECRET in cryptfs-tpm2 for your preference.
+4. The instruction below with the prefix "[TPM]" indicate the operation
+requires TPM hardware. Oppositely, the prefix "[Non-TPM]" indicates this
+operation is required if the target board doesn't have a working TPM hardware
+5. For development purpose, if the filename "passphrase" is present on the
+$boot, it will be handled by the /init.cryptfs in top priority even prior
+to using "encrypted_passphrase".
+
+Preparation
+-----------
+- Ensure a hard drive is attached on target board
+Note the following instrictions will wipe all data in the hard drive.
+
+- Create the usb image
+$ cd $project
+$ make usb-image
+
+- Deploy the usb image to a USB drive
+
+- Attach the boot device to the board
+
+- Power on
+
+- [TPM] Clear TPM
+Refer to feature/tpm2/README for the details.
+
+- Boot to Linux
+
+Use case 1: manual operation
+----------------------------
+
+Creation
+~~~~~~~~
+- Create at least 2 partitions on hard drive
+  * The first partition is used to boot system, called $boot.
+  * The second partition is the rootfs with the data encryption, called
+    $rootfs.
+
+- [TPM] Generate enough entropies for initialization
+# modprobe tpm-rng
+# rngd
+# export TSS_TCSD_HOSTNAME=127.0.0.1
+
+- [TPM] Create the encrypted passphrase file
+# mount /dev/$boot /mnt
+# tpm_gen_dmcrypt_key /mnt/encrypted_passphrase /tmp/passphrase
+# umount /mnt
+
+Note:
+The plain passphrase is sensitive information, so it is unsafe to save
+it to a disk-backed location. Make sure /tmp is mounted with RAM-based
+filesystem such as tpmfs.
+
+- [Non-TPM] Create the plain passphrase file
+# dd if=/dev/urandom of=/mnt/passphrase bs=1 count=32
+# cp -f /mnt/passphrase /tmp/passphrase
+
+Note:
+This instruction will place an insecure passphrase on $boot. So please
+ensure you know what your risk is to use them in your product.
+Alternately, omit this step and always type the passphrase whenever
+attempting to mount the encrypted rootfs.
+
+- [TPM] Create the LUKS partition
+# cryptsetup --type luks --cipher aes-xts-plain64 --hash sha512 \
+      --use-random --key-file /tmp/passphrase luksFormat /dev/$rootfs
+
+- [Non-TPM] Create the LUKS partition
+# cryptsetup --type luks --cipher aes-xts-plain64 --hash sha512 \
+      --use-random --key-file - luksFormat /dev/$rootfs
+
+The end user will be prompted to input the passphrase, or use the
+insecure plain passphrase.
+# cryptsetup --type luks --cipher aes-xts-plain64 --hash sha512 \
+      --use-random --key-file /tmp/passphrase luksFormat /dev/$rootfs
+
+- Open the LUKS partition
+# cryptsetup luksOpen --key-file /tmp/passphrase /dev/$rootfs $name
+
+- Remove the plain passphrase file
+# rm -f /tmp/passphrase
+
+- Create the filesystem/volume on the LUKS partition
+The user can run any available filesytem formatting program on
+/dev/mapper/$name to create the filesytem/volume with the data encryption.
+
+# mount /dev/mapper/$name /mnt
+
+The rootfs tarball can be extracted to this filesytem/volume for next boot,
+and the kernel and bootloader are placed to $boot.
+
+- Close the LUKS partition
+# umount /mnt
+# cryptsetup luksClose $name
+
+- Backup the persistent storage file for the use in initramfs
+# mount /dev/$boot /mnt
+# cp /var/lib/tpm/system.data /mnt
+
+- Create the new boot entry in grub.cfg, e.g, for the case of using the
+default project configuration with this template:
+# cat > /mnt/EFI/BOOT/grub.cfg << END_OF_GRUB_CFG
+menuentry 'Wind River Linux with LUKS' {
+    linux /bzImage-initramfs root=/dev/$rootfs rw rootwait
+}
+END_OF_GRUB_CFG
+or
+# cat > /mnt/EFI/BOOT/grub.cfg << END_OF_GRUB_CFG
+menuentry 'Wind River Linux with LUKS' {
+    chainloader /bzImage-initramfs root=/dev/$rootfs rw rootwait
+}
+END_OF_GRUB_CFG
+if feature/uefi-secure-boot or feature/mok-secure-boot configured.
+# umount /mnt
+
+- Reboot system
+
+- Detach the USB drive
+
+- Boot into initramfs
+The system will automatically boot into the initramfs after the reboot as long
+as a correct grub boot entry is created as above mentioned. 
+
+Note: The next section is informative only. The init script in initramfs
+will automatically run the following procedure without the necessity of
+user interaction, unless prompting the user to type a passphrase if the
+encrypted passphrase file is incorrect or not present.
+
+Mount Encrypted Rootfs
+~~~~~~~~~~~~~~~~~~~~~~
+- [TPM] Get the encrypted passphrase file and the persistent storage file
+# mount /dev/$boot /mnt
+# mkdir -p /var/lib/tpm
+# cp /mnt/system.data /var/lib/tpm
+# cp /mnt/encrypted_passphrase /tmp
+# umount /mnt
+
+- [TPM] Set up TPM
+# mknod /dev/tpm c 10 224
+# modprobe tpm_tis
+# export TSS_TCSD_HOSTNAME=127.0.0.1
+# ifconfig lo up
+# tcsd
+
+- [TPM] Unwrap the encrypted passphrase file
+# tpm_unwrap_dmcrypt_key /tmp/encrypted_passphrase /tmp/passphrase
+
+Note:
+The plain passphrase is sensitive information, so it is unsafe to save
+it to a disk-backed location. Make sure /tmp is mounted with RAM-based
+filesystem such as tpmfs.
+
+- [TPM] Open the LUKS partition
+# cryptsetup luksOpen --key-file /tmp/passphrase /dev/$rootfs $name
+
+- [Non-TPM] Open the LUKS partition
+# cryptsetup luksOpen --key-file - /dev/$rootfs $name
+The end user will be prompted to input the passphrase.
+
+- Remove the plain passphrase file
+# rm -f /tmp/passphrase
+
+- Copy the persistent storage file to the real rootfs
+# mount /dev/mapper/$name /mnt
+# cp -f /var/lib/tpm/system.data /mnt/var/lib/tpm
+
+- Switch to the real rootfs
+# switch_root /mnt /sbin/init
+
+Use case 2: initramfs
+---------------------
+initramfs employs a init script to automatically unseal the passphrase
+without any interaction.

--- a/templates/feature/storage-encryption/storage-encryption.cfg
+++ b/templates/feature/storage-encryption/storage-encryption.cfg
@@ -1,0 +1,11 @@
+# Enable device-mapper crypt target
+CONFIG_DM_CRYPT=y
+
+# Enable the default cipher-spec for LUKS
+CONFIG_CRYPTO_AES=y
+CONFIG_CRYPTO_AES_NI_INTEL=y
+CONFIG_CRYPTO_XTS=y
+
+# Use entropy-strong source for RNG
+CONFIG_HW_RANDOM=y
+CONFIG_HW_RANDOM_TPM=m

--- a/templates/feature/storage-encryption/storage-encryption.scc
+++ b/templates/feature/storage-encryption/storage-encryption.scc
@@ -1,0 +1,1 @@
+kconf non-hardware storage-encryption.cfg

--- a/templates/feature/storage-encryption/template.conf
+++ b/templates/feature/storage-encryption/template.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (C) 2016 Wind River Systems, Inc.
+#
+
+STORAGE_ENCRYPTION = "1"
+
+EXTRA_KERNEL_SRC_URI += "file://storage-encryption.scc"
+EXTRA_KERNEL_FILES =. "${LAYER_PATH_wr-security-packages}/templates/feature/storage-encryption:"


### PR DESCRIPTION
Data volume encryption allows the user to create encryption partition
with a passphrase typed by the end user.

This feature is ported from SCP8, with a big change that we support
TPM 2.0 only.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>