### PR TITLE
packagegroup-storage-encryption: add the cryptfs-tpm2

### DIFF
--- a/recipes-base/packagegroups/packagegroup-storage-encryption.inc
+++ b/recipes-base/packagegroups/packagegroup-storage-encryption.inc
@@ -26,6 +26,7 @@ RDEPENDS_${PN} = " \
     libtss2 \
     libtctidevice \
     libtctisocket \
+    cryptfs-tpm2 \
 "
 
 RRECOMMENDS_${PN} = "kernel-module-tpm-tis"


### PR DESCRIPTION
The package cryptfs-tpm2 is critical for creating LUKS partition for the
storage-encryption feature.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>