### PR TITLE
storage-encryption: support rootfs encryption

### DIFF
--- a/recipes-base/packagegroups/packagegroup-storage-encryption-initramfs.bb
+++ b/recipes-base/packagegroups/packagegroup-storage-encryption-initramfs.bb
@@ -1,0 +1,14 @@
+#
+# Copyright (C) 2016 Wind River Systems Inc.
+#
+
+include packagegroup-storage-encryption.inc
+
+DESCRIPTION = "The storage-encryption packages for initramfs."
+
+# Install the minimal stuffs only for the linux rootfs.
+# The common packages shared between initramfs and rootfs
+# are listed in the .inc.
+ROOTFS_BOOTSTRAP_INSTALL += " \
+    cryptfs-tpm2 \
+"

--- a/recipes-core/initrdscripts/files/init.cryptfs
+++ b/recipes-core/initrdscripts/files/init.cryptfs
@@ -1,0 +1,397 @@
+#!/bin/sh
+
+# Initramfs script called by /init
+#
+# This script is a halper used to decrypt and mount the rootfs
+# encrypted with cryptfs-tpm2.
+#
+# Copyright (c) 2016, Wind River Systems, Inc.
+# All rights reserved.
+# 
+# See "LICENSE" for license terms.
+# 
+# Author:
+#   Lans Zhang <jia.zhang@windriver.com>
+
+#
+# Global constant settings
+#
+
+# The tmpfs filesystem used to temporarily place the
+# passphrase file.
+TMP_DIR="/tmp"
+
+# The file name of the plain passphrase.
+PASSPHRASE="passphrase"
+
+# The maxinum number of passphrase retry
+MAX_PASSPHRASE_RETRY_COUNT=3
+
+#
+# Global variable settings
+#
+
+ROOTFS_DIR="${1:-/rootfs}"
+ROOTFS_DEV="$2"
+ROOTFS_MODE="${3:-rw}"
+# The mapping name of device-mapper crypt target for
+# the LUKS partition.
+LUKS_NAME="${4:-cryptfs}"
+
+TPM_TIS_MODULE_LOADED=0
+TPM_CRB_MODULE_LOADED=0
+TPM_DEVICE=""
+
+function print_critical
+{
+    printf "\033[1;35m"
+    echo "$@"
+    printf "\033[0m"
+}
+
+function print_error
+{
+    printf "\033[1;31m"
+    echo "$@"
+    printf "\033[0m"
+}
+
+function print_warning
+{
+    printf "\033[1;33m"
+    echo "$@"
+    printf "\033[0m"
+}
+
+function print_info
+{
+    printf "\033[1;32m"
+    echo "$@"
+    printf "\033[0m"
+}
+
+function print_verbose
+{
+    printf "\033[1;36m"
+    echo "$@"
+    printf "\033[0m"
+}
+
+function create_dir
+{
+    local dir="$1"
+
+    if [ ! -d "$dir" ]; then
+        mkdir -p "$dir" || return 1
+    fi
+
+    return 0
+}
+
+function get_dev_uuid
+{
+    blkid -t UUID=$1 -l | awk -F: '{print $1}'
+}
+
+function get_dev_partuuid
+{
+    blkid 2> /dev/null | grep "PARTUUID=\"$1\"" | grep -o "^[^: ]*"
+}
+
+function get_dev_label
+{
+    blkid -t LABEL=$1 -l | awk -F: '{print $1}'
+}
+
+function get_dev_rawdev
+{
+    [ -e /sys/class/block/`basename "$1"` ] && echo $1
+}
+
+function parse_rootfs_dev_path
+{
+    local ret_type="$1"
+    local ret_name="$2"
+    local dev_type dev_name
+
+    # Determine the type of root device
+    for i in "UUID" "PARTUUID" "LABEL" "" ; do
+        local word=${i:+"$i="}
+        local root=$(grep -o "\<root=${word}[^= ]*" /proc/cmdline)
+
+        dev_name=$(echo "$root" | awk -F'=' '{print $NF}' | sed 's/"//g')
+        dev_type=${i:-"RAWDEV"}
+        [ -n "$dev_name" ] && break
+    done
+
+    if [ -z "$dev_name" -o -z "$dev_type" ]; then
+        print_error "Empty root= option, cannot proceed to boot!"
+        return 1
+    fi
+
+    [ -n "$ret_type" ] && eval $ret_type="$dev_type"
+    [ -n "$ret_name" ] && eval $ret_name="$dev_name"
+
+    print_verbose "device path: $dev_type=$dev_name"
+
+    return 0
+}
+
+function get_rawdev
+{
+    local type="$1"
+    local name="$2"
+    local ret_rawdev="$3"
+    local rawdev
+
+    case "$type" in
+        UUID)     rawdev=$(get_dev_uuid $name) ;;
+        PARTUUID) rawdev=$(get_dev_partuuid $name) ;;
+        LABEL)    rawdev=$(get_dev_label $name) ;;
+        RAWDEV)   rawdev=$(get_dev_rawdev $name) ;;
+    esac
+
+    if [ -n "$rawdev" ] ; then
+        [ -n "$ret_rawdev" ] && eval $ret_rawdev="$rawdev"
+        print_info "Found root device: $rawdev"
+        return 0
+    fi
+
+    print_error "Unable to find raw device for $type=$name!"
+
+    return 1
+}
+
+function detect_tpm_chip
+{
+    local ret_absent="$1"
+
+    [ ! -e /sys/class/tpm ] && print_info "TPM subsystem is not enabled." && return 1
+
+    depmod -a
+    ! grep -q "^tpm_tis" /proc/modules && modprobe --quiet tpm_tis && TPM_TIS_MODULE_LOADED=1
+    ! grep -q "^tpm_crb" /proc/modules && modprobe --quiet tpm_crb && TPM_CRB_MODULE_LOADED=1
+
+    local tpm_devices=$(ls /sys/class/tpm)
+    [ -z "$tpm_devices" ] && print_info "No TPM chip detected." && return 1
+
+    local tpm_absent=1
+    local name=""
+    for name in $tpm_devices; do
+        grep -q "TCG version: 1.2" "/sys/class/tpm/$name/device/caps" 2>/dev/null &&
+            print_info "TPM 1.2 device $name is not supported." && break
+
+        grep -q "TPM 2.0 Device" "/sys/class/tpm/$name/device/description" 2>/dev/null &&
+            tpm_absent=0 && break
+    done
+
+    [ $tpm_absent -eq 1 ] && print_info "No supported TPM device found." && return 1
+
+    local name_in_dev="$name"
+    # /dev/tpm is the alias of /dev/tpm0.
+    [ "$name_in_dev" = "tpm0" ] && name_in_dev+=" tpm"
+
+    local _name=""
+    for _name in $name_in_dev; do
+        [ -c "/dev/$_name" ] && break
+
+        local major=$(cat "/sys/class/tpm/$name/dev" | cut -d ":" -f 1)
+        local minor=$(cat "/sys/class/tpm/$name/dev" | cut -d ":" -f 2)
+        ! mknod "/dev/$_name" c $major $minor &&
+            print_error "Unable to create tpm device node $_name." && return 1
+
+        TPM_DEVICE="/dev/$_name"
+
+        break
+    done
+
+    [ -n "$ret_absent" ] && eval $ret_absent=$tpm_absent
+
+    print_info "TPM device /dev/$_name detected."
+
+    return 0
+}
+
+function open_luks_part_with_encrypted_passphrase
+{
+    local luks_rawdev="$1"
+
+    (! /usr/sbin/resourcemgr && print_info "resourcemgr killed") &
+
+    # Wait for resourcemgr starting work.
+    sleep 1
+
+    # Unseal the passphrase
+    ! cryptfs-tpm2 unseal passphrase -o "$TMP_DIR/$PASSPHRASE" &&
+        print_error "Unable to unseal the passphrase" && return 1
+
+    ! cryptsetup luksOpen --key-file "$TMP_DIR/$PASSPHRASE" "$luks_rawdev" "$LUKS_NAME" &&
+        print_error "Unable to open the LUKS partition $luks_rawdev with the encrypted passphrase" && return 1
+
+    print_verbose "The LUKS partition $luks_rawdev is opened with the encrypted passphrase"
+
+    # Remove the plain passphrase file
+    ! rm -f "$TMP_DIR/$PASSPHRASE" && print_error "Unable to remove the decrypted passphrase file" && return 1
+
+    return 0
+}
+
+function open_luks_part_with_typed_passphrase
+{
+    local luks_rawdev="$1"
+    local i=1
+    for i in `seq $MAX_PASSPHRASE_RETRY_COUNT`; do
+        cryptsetup luksOpen --key-file - "$luks_rawdev" "$LUKS_NAME" &&
+            print_verbose "The LUKS partition $luks_rawdev is opened with the typed passphrase" &&
+            return 0
+
+        [ $(($MAX_PASSPHRASE_RETRY_COUNT - $i)) -ne 0 ] &&
+            print_warning "Passphrase incorrect. $(($MAX_PASSPHRASE_RETRY_COUNT - $i))-time remaining ..."
+    done
+
+    print_error "Failed to open the LUKS partition $luks_rawdev with the typed passphrase"
+
+    return 1
+}
+
+# Alway attempt to map LUKS rootfs with an appropriate passphrase in
+# this order:
+# - Persistent passphrase if present in TPM
+# - Password prompt
+function map_luks
+{
+    local luks_rawdev="$1"
+    local tpm_absent=$2
+
+    print_verbose "Attempting to mount the LUKS partition $luks_rawdev ..."
+
+    local err=1
+    if [ $tpm_absent -eq 0 ]; then
+        open_luks_part_with_encrypted_passphrase "$luks_rawdev"
+        err=$?
+    fi
+
+    rm -f "$TMP_DIR/$PASSPHRASE"
+    pkill -9 resourcemgr
+
+    if [ $err -eq 1 ]; then
+        print_verbose "Attempting to prompt with inputing passphrase ..."
+
+        open_luks_part_with_typed_passphrase "$luks_rawdev"
+        err=$?
+    fi
+
+    return $err
+}
+
+function mount_luks
+{
+    local err=0
+
+    mount -o "$ROOTFS_MODE" "/dev/mapper/$LUKS_NAME" "$ROOTFS_DIR" ||
+        (err=1 && [ -e "/dev/mapper/$LUKS_NAME" ] && cryptsetup luksClose "$LUKS_NAME")
+
+    return $err
+}
+
+function trap_handler
+{
+    local err=$?
+
+    print_verbose "Cleaning up with exit code $err ..."
+
+    if [ $err -ne 0 ]; then
+        if [ -d "$ROOTFS_DIR" ]; then
+            umount "$ROOTFS_DIR" 2>/dev/null
+            rm -rf "$ROOTFS_DIR" 2>/dev/null
+        fi
+
+        cryptsetup luksClose "$LUKS_NAME" 2>/dev/null
+    fi
+
+    rm -f "$TMP_DIR/$PASSPHRASE" 2>/dev/null
+
+    pkill -9 resourcemgr
+    [ $TPM_TIS_MODULE_LOADED -eq 1 ] && modprobe --quiet -r tpm_tis
+    [ $TPM_CRB_MODULE_LOADED -eq 1 ] && modprobe --quiet -r tpm_crb    
+    [ ! -z "$TPM_DEVICE" ] && rm -f "$TPM_DEVICE" 2>/dev/null
+
+    if [ $TMP_DIR_MOUNTED -eq 1 ]; then
+        umount "$TMP_DIR" 2>/dev/null
+        rm -rf "$TMP_DIR" 2>/dev/null
+    fi
+}
+
+
+trap "trap_handler $?" SIGINT EXIT
+
+# Detect the present of LUKS partition.
+
+luks_rawdev_pathes="$(blkid -o list | grep crypto_LUKS | awk '{ print $1 }')"
+[ -z "$luks_rawdev_pathes" ] && print_info "No LUKS partition detected" && exit 1
+
+! parse_rootfs_dev_path rootfs_dev_path_type rootfs_dev_path_name && exit 1
+
+# root=LABEL=xxx cannot be parsed until the LUKS partition is mounted.
+! get_rawdev $rootfs_dev_path_type $rootfs_dev_path_name rootfs_rawdev &&
+    [ "$rootfs_dev_path_type" != "LABEL" ] && exit 1
+
+# Overwrite LUKS_NAME if root=LABEL=xxx is specified.
+[ "$rootfs_dev_path_type" = "LABEL" ] && [ -n "$rootfs_dev_path_name" ] &&
+    LUKS_NAME="$rootfs_dev_path_name"
+
+# Make sure the plain passphrase will be saved in a RAM-based
+# filesystem to avoid the risk of exposing it.
+
+if ! create_dir "$TMP_DIR"; then
+    print_error "Unable to create $TMP_DIR for mounting tmpfs filesystem"
+    exit 1
+fi
+
+TMP_DIR_MOUNTED=0
+if ! grep -q "$TMP_DIR" /proc/mounts; then
+   ! mount -t tmpfs none "$TMP_DIR" 2>/dev/null &&
+       print_error "Unable to mount tmpfs filesystem" && exit 1
+   TMP_DIR_MOUNTED=1
+else
+   tmp_dir_fs_types="$(grep "$TMP_DIR" /proc/mounts | awk '{print $3}')"
+
+   for fs_type in $tmp_dir_fs_types; do
+       [ "$fs_type" != "tmpfs" ] &&
+           print_error "/tmp is mounted with $fs_type != tmpfs" && exit 1
+   done
+fi
+
+# Probe TPM.
+
+tpm_absent=1
+if detect_tpm_chip tpm_absent; then
+    ! ifconfig lo up && print_error "Unable to active the loop interface" && exit 1
+    tpm_absent=0
+else
+    tpm_absent=1
+fi
+
+! create_dir "$ROOTFS_DIR" && print_error "Unable to create $ROOTFS_DIR" && exit 1
+
+# Check whether the LUKS partition is specified in root=.
+err=1
+for luks_rawdev in $luks_rawdev_pathes; do
+    [ -n "$rootfs_rawdev" -a "$rootfs_rawdev" != "$luks_rawdev" ] && continue
+ 
+    ! map_luks $luks_rawdev $tpm_absent && break
+    ! mount_luks && break
+
+    [ -z "$rootfs_rawdev" ] && ! get_rawdev $rootfs_dev_path_type $rootfs_dev_path_name rootfs_rawdev &&
+        continue
+
+    err=0
+    break
+done
+
+[ $err -eq 1 ] &&
+    print_info "Unable to mount the rootfs device" && exit 1
+
+print_info "The LUKS partition $luks_rawdev is mounted as rootfs successfully"
+
+exit 0

--- a/recipes-core/initrdscripts/initramfs-cube-builder.bbappend
+++ b/recipes-core/initrdscripts/initramfs-cube-builder.bbappend
@@ -1,0 +1,39 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "\
+    file://init.cryptfs \
+"
+
+do_install_append() {
+    install -m 0755 ${WORKDIR}/init.cryptfs ${D}
+}
+
+FILES_${PN} += "/init.cryptfs"
+
+# Install the minimal stuffs only, and don't care how the external
+# environment is configured.
+# @bash: sh
+# @coreutils: echo, mkdir, mknod, dirname, basename, cp, rm, sleep
+#             seq, printf, cut
+# @grep: grep
+# @gawk: awk
+# @kmod: modprobe, depmod
+# @net-tools: ifconfig
+# @trousers: tcsd
+# @procps: pkill
+# @util-linux: blkid, mount, umount
+RDEPENDS_${PN} += "\
+    bash \
+    coreutils \
+    grep \
+    gawk \
+    kmod \
+    net-tools \
+    procps \
+    util-linux-blkid \
+    util-linux-mount \
+    util-linux-umount \
+    packagegroup-storage-encryption-initramfs \
+"
+
+RRECOMMENDS_${PN} += "kernel-module-efivarfs"

--- a/recipes-tpm/cryptfs-tpm2/cryptfs-tpm2_git.bb
+++ b/recipes-tpm/cryptfs-tpm2/cryptfs-tpm2_git.bb
@@ -15,8 +15,8 @@ LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=af9aa760caa1532b4f5c9874d4e8c753"
 SRC_URI = " \
     git://github.com/WindRiver-OpenSourceLabs/cryptfs-tpm2.git \
 "
-SRCREV = "cc40708796019c9bee28e0fe119f6409d5aa1215"
-PV = "0.2.1+git${SRCPV}"
+SRCREV = "e62cb78073cba39c61b821803cab8c558c3b4eb5"
+PV = "0.3.0+git${SRCPV}"
 
 DEPENDS += "tpm2.0-tss"
 RDEPENDS_${PN} += "libtss2 libtctisocket"

--- a/templates/feature/storage-encryption/README
+++ b/templates/feature/storage-encryption/README
@@ -62,6 +62,8 @@ In runtime, for example, create LUKS partition on /dev/sdb1 with the
 name "my_luks_part":
 # luks-setup.sh -d /dev/sdb1 -n my_luks_name
 
+Note: if TPM is detected, the passphrase will be generated automatically.
+
 Next refer to "Create the filesystem/volume on the LUKS partition" to manually
 create the filesystem/volume.
 
@@ -87,22 +89,19 @@ CRYPTFS_TPM2_PASSPHRASE_SECRET in cryptfs-tpm2 for your preference.
 4. The instruction below with the prefix "[TPM]" indicate the operation
 requires TPM hardware. Oppositely, the prefix "[Non-TPM]" indicates this
 operation is required if the target board doesn't have a working TPM hardware
-5. For development purpose, if the filename "passphrase" is present on the
-$boot, it will be handled by the /init.cryptfs in top priority even prior
-to using "encrypted_passphrase".
+5. If TPM is not present on target board, the passphrase will have to be
+typed whenever creating the LUKS partition or mounting it during the boot.
 
 Preparation
 -----------
 - Ensure a hard drive is attached on target board
-Note the following instrictions will wipe all data in the hard drive.
+Note the following instructions will wipe all data in the hard drive.
 
-- Create the usb image
-$ cd $project
-$ make usb-image
+- Create overc installer on a USB device
+Refer to layers/meta-overc/README.install for the details about how to
+run cubeit to install overc installer to a USB device.
 
-- Deploy the usb image to a USB drive
-
-- Attach the boot device to the board
+- Attach the USB device to the board
 
 - Power on
 
@@ -111,148 +110,12 @@ Refer to feature/tpm2/README for the details.
 
 - Boot to Linux
 
-Use case 1: manual operation
-----------------------------
+- Install overc runtime on the hard drive
+Refer to layers/meta-overc/README.install for the details about how to
+run cubeit-installer to install overc runtime to a hard drive. In
+addition, beware of specifying "--encryption" option to set up an
+encrypted rootfs.
 
-Creation
-~~~~~~~~
-- Create at least 2 partitions on hard drive
-  * The first partition is used to boot system, called $boot.
-  * The second partition is the rootfs with the data encryption, called
-    $rootfs.
-
-- [TPM] Generate enough entropies for initialization
-# modprobe tpm-rng
-# rngd
-# export TSS_TCSD_HOSTNAME=127.0.0.1
-
-- [TPM] Create the encrypted passphrase file
-# mount /dev/$boot /mnt
-# tpm_gen_dmcrypt_key /mnt/encrypted_passphrase /tmp/passphrase
-# umount /mnt
-
-Note:
-The plain passphrase is sensitive information, so it is unsafe to save
-it to a disk-backed location. Make sure /tmp is mounted with RAM-based
-filesystem such as tpmfs.
-
-- [Non-TPM] Create the plain passphrase file
-# dd if=/dev/urandom of=/mnt/passphrase bs=1 count=32
-# cp -f /mnt/passphrase /tmp/passphrase
-
-Note:
-This instruction will place an insecure passphrase on $boot. So please
-ensure you know what your risk is to use them in your product.
-Alternately, omit this step and always type the passphrase whenever
-attempting to mount the encrypted rootfs.
-
-- [TPM] Create the LUKS partition
-# cryptsetup --type luks --cipher aes-xts-plain64 --hash sha512 \
-      --use-random --key-file /tmp/passphrase luksFormat /dev/$rootfs
-
-- [Non-TPM] Create the LUKS partition
-# cryptsetup --type luks --cipher aes-xts-plain64 --hash sha512 \
-      --use-random --key-file - luksFormat /dev/$rootfs
-
-The end user will be prompted to input the passphrase, or use the
-insecure plain passphrase.
-# cryptsetup --type luks --cipher aes-xts-plain64 --hash sha512 \
-      --use-random --key-file /tmp/passphrase luksFormat /dev/$rootfs
-
-- Open the LUKS partition
-# cryptsetup luksOpen --key-file /tmp/passphrase /dev/$rootfs $name
-
-- Remove the plain passphrase file
-# rm -f /tmp/passphrase
-
-- Create the filesystem/volume on the LUKS partition
-The user can run any available filesytem formatting program on
-/dev/mapper/$name to create the filesytem/volume with the data encryption.
-
-# mount /dev/mapper/$name /mnt
-
-The rootfs tarball can be extracted to this filesytem/volume for next boot,
-and the kernel and bootloader are placed to $boot.
-
-- Close the LUKS partition
-# umount /mnt
-# cryptsetup luksClose $name
-
-- Backup the persistent storage file for the use in initramfs
-# mount /dev/$boot /mnt
-# cp /var/lib/tpm/system.data /mnt
-
-- Create the new boot entry in grub.cfg, e.g, for the case of using the
-default project configuration with this template:
-# cat > /mnt/EFI/BOOT/grub.cfg << END_OF_GRUB_CFG
-menuentry 'Wind River Linux with LUKS' {
-    linux /bzImage-initramfs root=/dev/$rootfs rw rootwait
-}
-END_OF_GRUB_CFG
-or
-# cat > /mnt/EFI/BOOT/grub.cfg << END_OF_GRUB_CFG
-menuentry 'Wind River Linux with LUKS' {
-    chainloader /bzImage-initramfs root=/dev/$rootfs rw rootwait
-}
-END_OF_GRUB_CFG
-if feature/uefi-secure-boot or feature/mok-secure-boot configured.
-# umount /mnt
-
-- Reboot system
-
-- Detach the USB drive
-
-- Boot into initramfs
-The system will automatically boot into the initramfs after the reboot as long
-as a correct grub boot entry is created as above mentioned. 
-
-Note: The next section is informative only. The init script in initramfs
-will automatically run the following procedure without the necessity of
-user interaction, unless prompting the user to type a passphrase if the
-encrypted passphrase file is incorrect or not present.
-
-Mount Encrypted Rootfs
-~~~~~~~~~~~~~~~~~~~~~~
-- [TPM] Get the encrypted passphrase file and the persistent storage file
-# mount /dev/$boot /mnt
-# mkdir -p /var/lib/tpm
-# cp /mnt/system.data /var/lib/tpm
-# cp /mnt/encrypted_passphrase /tmp
-# umount /mnt
-
-- [TPM] Set up TPM
-# mknod /dev/tpm c 10 224
-# modprobe tpm_tis
-# export TSS_TCSD_HOSTNAME=127.0.0.1
-# ifconfig lo up
-# tcsd
-
-- [TPM] Unwrap the encrypted passphrase file
-# tpm_unwrap_dmcrypt_key /tmp/encrypted_passphrase /tmp/passphrase
-
-Note:
-The plain passphrase is sensitive information, so it is unsafe to save
-it to a disk-backed location. Make sure /tmp is mounted with RAM-based
-filesystem such as tpmfs.
-
-- [TPM] Open the LUKS partition
-# cryptsetup luksOpen --key-file /tmp/passphrase /dev/$rootfs $name
-
-- [Non-TPM] Open the LUKS partition
-# cryptsetup luksOpen --key-file - /dev/$rootfs $name
-The end user will be prompted to input the passphrase.
-
-- Remove the plain passphrase file
-# rm -f /tmp/passphrase
-
-- Copy the persistent storage file to the real rootfs
-# mount /dev/mapper/$name /mnt
-# cp -f /var/lib/tpm/system.data /mnt/var/lib/tpm
-
-- Switch to the real rootfs
-# switch_root /mnt /sbin/init
-
-Use case 2: initramfs
----------------------
-initramfs employs a init script to automatically unseal the passphrase
-without any interaction.
+- Reboot
+After reboot to initramfs, it employs a init script to transparently
+unseal the passphrase and mount the rootfs without any interaction.


### PR DESCRIPTION
This feature is inherited from SCP8 with the following changes:

- Use TPM 2.0 as the secure storage to protect the passphrase.
- The creation process is made in cubeit-installer.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>