### PR TITLE
packagegroup-storage-encryption-initramfs: remove the duplication

### DIFF
--- a/recipes-base/packagegroups/packagegroup-storage-encryption-initramfs.bb
+++ b/recipes-base/packagegroups/packagegroup-storage-encryption-initramfs.bb
@@ -5,10 +5,3 @@
 include packagegroup-storage-encryption.inc
 
 DESCRIPTION = "The storage-encryption packages for initramfs."
-
-# Install the minimal stuffs only for the linux rootfs.
-# The common packages shared between initramfs and rootfs
-# are listed in the .inc.
-ROOTFS_BOOTSTRAP_INSTALL += " \
-    cryptfs-tpm2 \
-"


### PR DESCRIPTION
cryptfs-tpm2 is already included in .inc.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>