### PR TITLE
init.crypt: don't use rm -rf to delete the dir

### DIFF
--- a/recipes-core/initrdscripts/files/init.cryptfs
+++ b/recipes-core/initrdscripts/files/init.cryptfs
@@ -304,7 +304,7 @@ function trap_handler
     if [ $err -ne 0 ]; then
         if [ -d "$ROOTFS_DIR" ]; then
             umount "$ROOTFS_DIR" 2>/dev/null
-            rm -rf "$ROOTFS_DIR" 2>/dev/null
+            rmdir --ignore-fail-on-non-empty "$ROOTFS_DIR" 2>/dev/null
         fi
 
         cryptsetup luksClose "$LUKS_NAME" 2>/dev/null
@@ -319,7 +319,7 @@ function trap_handler
 
     if [ $TMP_DIR_MOUNTED -eq 1 ]; then
         umount "$TMP_DIR" 2>/dev/null
-        rm -rf "$TMP_DIR" 2>/dev/null
+        rmdir --ignore-fail-on-non-empty "$TMP_DIR" 2>/dev/null
     fi
 }
 


### PR DESCRIPTION
rm -rf will work without any side effect only when the rootfs mount
point is not specified by the caller. In pulsar runtime, the mount
point is always set and thus the cleanup will wrongly remove the
entire rootfs mount point, leading the failure of mounting the rootfs.

This same issue occurs too with /tmp dir.

To fix this issue, use the safe rmdir.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>