### PR TITLE
Fix boot failure due to wrongly removing mount point for rootfs

### DIFF
--- a/recipes-core/initrdscripts/files/init.cryptfs
+++ b/recipes-core/initrdscripts/files/init.cryptfs
@@ -304,7 +304,6 @@ function trap_handler
     if [ $err -ne 0 ]; then
         if [ -d "$ROOTFS_DIR" ]; then
             umount "$ROOTFS_DIR" 2>/dev/null
-            rmdir --ignore-fail-on-non-empty "$ROOTFS_DIR" 2>/dev/null
         fi
 
         cryptsetup luksClose "$LUKS_NAME" 2>/dev/null


### PR DESCRIPTION
If there is no LUKS partition and the first mount attempt fails,
the init.cryptfs is called and the cleanup will wrongly remove
the ROOTFS_DIR where the init script created before calling
init.cryptfs.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>