### PR TITLE
meta-secure-env: fix boot failure if data encrypted partition exists

### DIFF
--- a/recipes-core/initrdscripts/files/init.cryptfs
+++ b/recipes-core/initrdscripts/files/init.cryptfs
@@ -332,9 +332,23 @@ luks_rawdev_pathes="$(blkid -o list | grep crypto_LUKS | awk '{ print $1 }')"
 
 ! parse_rootfs_dev_path rootfs_dev_path_type rootfs_dev_path_name && exit 1
 
+get_rawdev $rootfs_dev_path_type $rootfs_dev_path_name rootfs_rawdev
+if [ $? -eq 0 ]; then
+    # Check whether the rootfs device is a LUKS partition.
+    err=1
+    for luks_rawdev in $luks_rawdev_pathes; do
+        [ "$rootfs_rawdev" = "$luks_rawdev" ] && err=0 && break
+    done
+
+    if [ $err -eq 1 ]; then
+        print_info "The specified rootfs is not a LUKS partition"
+        exit 1
+    fi
+fi
+
 # root=LABEL=xxx cannot be parsed until the LUKS partition is mounted.
-! get_rawdev $rootfs_dev_path_type $rootfs_dev_path_name rootfs_rawdev &&
-    [ "$rootfs_dev_path_type" != "LABEL" ] && exit 1
+[ "$rootfs_dev_path_type" != "LABEL" ] &&
+    print_error "Unable to locate the specified rootfs" && exit 1
 
 # Overwrite LUKS_NAME if root=LABEL=xxx is specified.
 [ "$rootfs_dev_path_type" = "LABEL" ] && [ -n "$rootfs_dev_path_name" ] &&

--- a/templates/feature/storage-encryption/README
+++ b/templates/feature/storage-encryption/README
@@ -60,9 +60,11 @@ Basically this script wraps the manual instructions above.
 
 In runtime, for example, create LUKS partition on /dev/sdb1 with the
 name "my_luks_part":
-# luks-setup.sh -d /dev/sdb1 -n my_luks_name
+# luks-setup.sh -d /dev/sdb1 -n my_luks_name -e
 
 Note: if TPM is detected, the passphrase will be generated automatically.
+
+For more uses about luks-setup.sh, run it with -h option.
 
 Next refer to "Create the filesystem/volume on the LUKS partition" to manually
 create the filesystem/volume.


### PR DESCRIPTION
If a non-rootfs LUKS partition was created, the init.cryptfs should stop attempting to mount it.