### PR TITLE
IMA: initial implementation for runtime

### DIFF
--- a/recipes-base/packagegroups/packagegroup-ima-initramfs.bb
+++ b/recipes-base/packagegroups/packagegroup-ima-initramfs.bb
@@ -1,0 +1,13 @@
+#
+# Copyright (C) 2016 Wind River Systems Inc.
+#
+
+DESCRIPTION = "Linux Integrity Measurement Architecture (IMA) subsystem for initramfs"
+
+include packagegroup-ima.inc
+
+RDEPENDS_${PN} += " \
+    keyutils \
+    ima-policy \
+    util-linux-switch_root.static \
+"

--- a/recipes-base/packagegroups/packagegroup-ima.bb
+++ b/recipes-base/packagegroups/packagegroup-ima.bb
@@ -1,0 +1,11 @@
+#
+# Copyright (C) 2017 Wind River Systems Inc.
+#
+
+DESCRIPTION = "Linux Integrity Measurement Architecture (IMA) subsystem"
+
+include packagegroup-ima.inc
+
+RDEPENDS_${PN} += " \
+    key-store-ima-privkey \
+"

--- a/recipes-base/packagegroups/packagegroup-ima.inc
+++ b/recipes-base/packagegroups/packagegroup-ima.inc
@@ -1,0 +1,14 @@
+#
+# Copyright (C) 2017 Wind River Systems Inc.
+#
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690 \
+                    file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+ALLOW_EMPTY_${PN} = "1"
+
+RDEPENDS_${PN} = " \
+    ima-evm-utils \
+    key-store-ima-pubkey \
+"

--- a/recipes-bsp/grub/grub-efi_2.00.bbappend
+++ b/recipes-bsp/grub/grub-efi_2.00.bbappend
@@ -59,6 +59,10 @@ do_install_append_class-target() {
         sed -i '/^\s*initrd /d' $cfg
     fi
 
+    # Enable integrity audit log and the default IMA rules if IMA is enabled.
+    [ x"${IMA}" = x"1" ] &&
+        sed -i 's/^\s*chainloader .*rootwait.*/& integrity_audit=1 ima_policy=tcb/' $cfg
+
     # Create a boot entry for Automatic Key Provision. This is required because
     # certain hardware, e.g, Intel NUC5i3MYHE, doedn't support to display a
     # customized BIOS boot option used to launch LockDown.efi.

--- a/recipes-core/initrdscripts/files/init.ima
+++ b/recipes-core/initrdscripts/files/init.ima
@@ -1,0 +1,135 @@
+#!/bin/sh
+
+# Initramfs script for IMA initialzation
+#
+# This script is a halper used to load the external
+# IMA policy and public keys used to verify the IMA
+# signature.
+#
+# Copyright (c) 2017, Wind River Systems, Inc.
+# All rights reserved.
+# 
+# See "LICENSE" for license terms.
+# 
+# Author:
+#   Lans Zhang <jia.zhang@windriver.com>
+
+# Exit code:
+# 0 - IMA initialiazation complete
+# 1 - Kernel doesn't support securityfs
+# 2 - Kernel doesn't support IMA
+# 3 - There is no public key to load
+# 4 - There is no IMA policy file defined
+# 5 - Unable to load IMA policy file
+
+# If root directory is not specified, the root of
+# initramfs assumed.
+ROOT_DIR="${1}"
+
+SECURITYFS_DIR=${ROOT_DIR}/sys/kernel/security
+
+# The policy files are always placed in initramfs
+IMA_POLICY=/etc/ima_policy
+
+PUBKEY_LOADED=0
+SECURITYFS_MOUNTED=0
+
+export PATH="${ROOT_DIR}/usr/sbin:${ROOT_DIR}/usr/bin:${ROOT_DIR}/sbin:${ROOT_DIR}/bin:${PATH}"
+
+function print_critical
+{
+    printf "\033[1;35m"
+    echo "$@"
+    printf "\033[0m"
+}
+
+function print_error
+{
+    printf "\033[1;31m"
+    echo "$@"
+    printf "\033[0m"
+}
+
+function print_warning
+{
+    printf "\033[1;33m"
+    echo "$@"
+    printf "\033[0m"
+}
+
+function print_info
+{
+    printf "\033[1;32m"
+    echo "$@"
+    printf "\033[0m"
+}
+
+function print_verbose
+{
+    printf "\033[1;36m"
+    echo "$@"
+    printf "\033[0m"
+}
+
+function trap_handler
+{
+    local err=$?
+
+    print_verbose "Cleaning up with exit code $err ..."
+
+    if [ $err -ne 0 ]; then
+        [ $PUBKEY_LOADED -eq 1 ] && keyctl revoke $keyring_id
+    fi
+
+    [ $SECURITYFS_MOUNTED -eq 1 ] &&
+        umount "$SECURITYFS_DIR" 2>${ROOT_DIR}/dev/null
+}
+
+trap "trap_handler $?" SIGINT EXIT
+
+if ! grep -q securityfs ${ROOT_DIR}/proc/mounts; then
+   ! mount -t securityfs none "$SECURITYFS_DIR" 2>${ROOT_DIR}/dev/null &&
+       print_error "Unable to mount securityfs filesystem" && exit 1
+   SECURITYFS_MOUNTED=1
+   securityfs_dir="$SECURITYFS_DIR"
+else
+   securityfs_dirs="$(grep securityfs ${ROOT_DIR}/proc/mounts | awk '{print $2}')"
+
+   # Use the first one.
+   for securityfs_dir in "$securityfs_dirs"; do
+       break
+   done
+fi
+
+[ ! -d "$securityfs_dir/ima" ] &&
+    print_info "IMA is not enabled. Exiting ..." && exit 2
+
+if grep -q 'ima_appraise=off' ${ROOT_DIR}/proc/cmdline; then
+    print_info "Skip to load the public key for IMA appraise"
+else
+    keyring_id=`keyctl newring _ima @u`
+
+    for key in /etc/keys/pubkey_evm*.pem; do
+        if ! evmctl import --rsa $key $keyring_id >${ROOT_DIR}/dev/null; then
+            print_critical "Unable to load the public key $key for IMA appraise"
+        else
+            PUBKEY_LOADED=1
+            print_verbose "The public key $key loaded for IMA appraise"
+        fi
+    done
+
+    [ $PUBKEY_LOADED -ne 1 ] && print_warning "No public key loaded" && exit 3
+fi
+
+# Attempt to load the default policy.
+[ ! -f "${IMA_POLICY}" ] && IMA_POLICY="${IMA_POLICY}.default"
+
+[ ! -f "${IMA_POLICY}" ] && print_warning "No IMA policy file defined" && exit 4
+
+cat "${IMA_POLICY}" > "$securityfs_dir/ima/policy" && {
+    print_info "IMA policy ${IMA_POLICY} loaded"
+    exit 0
+} || {
+    print_critical "Unable to load the IMA policy ${IMA_POLICY}"
+    exit 5
+}

--- a/recipes-core/initrdscripts/initramfs-cube-builder.bbappend
+++ b/recipes-core/initrdscripts/initramfs-cube-builder.bbappend
@@ -2,15 +2,23 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI += "\
     file://init.cryptfs \
+    file://init.ima \
 "
 
 do_install_append() {
     if [ x"${STORAGE_ENCRYPTION}" = x"1" ]; then
-        install -m 0755 ${WORKDIR}/init.cryptfs ${D}
+        install -m 0500 ${WORKDIR}/init.cryptfs ${D}
+    fi
+
+    if [ x"${IMA}" = x"1" ]; then
+        install -m 0500 ${WORKDIR}/init.ima ${D}
     fi
 }
 
-FILES_${PN} += "/init.cryptfs"
+FILES_${PN} += " \
+    /init.cryptfs \
+    /init.ima \
+"
 
 # Install the minimal stuffs only, and don't care how the external
 # environment is configured.
@@ -35,7 +43,6 @@ RDEPENDS_${PN} += "\
     util-linux-blkid \
     util-linux-mount \
     util-linux-umount \
-    packagegroup-storage-encryption-initramfs \
 "
 
 RRECOMMENDS_${PN} += "kernel-module-efivarfs"

--- a/recipes-core/util-linux/util-linux_%.bbappend
+++ b/recipes-core/util-linux/util-linux_%.bbappend
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2017 Wind River Systems, Inc.
+#
+
+PACKAGES =+ "${PN}-switch_root.static"
+
+do_compile_append_class-target() {
+    ${CC} ${CFLAGS} ${LDFLAGS} -static sys-utils/switch_root.o \
+        -o ${B}/switch_root.static
+}
+
+do_install_append_class-target() {
+    install -d ${D}/sbin
+    install -m 0755 ${B}/switch_root.static ${D}/sbin/switch_root.static
+}
+
+FILES_${PN}-switch_root.static = "/sbin/switch_root.static"

--- a/recipes-support/ima-policy/files/ima_policy.default
+++ b/recipes-support/ima-policy/files/ima_policy.default
@@ -1,0 +1,23 @@
+# The default external IMA policy
+
+# Don't appraise any file opened.
+dont_appraise func=FILE_CHECK
+# Reduce performance loss
+# audit func=FILE_CHECK fowner=0 mask=^MAY_READ
+# measure func=FILE_CHECK fowner=0 mask=^MAY_READ
+
+measure func=MMAP_CHECK euid=0
+appraise func=MMAP_CHECK euid=0 appraise_type=imasig
+audit func=MMAP_CHECK euid=0
+
+measure func=BPRM_CHECK euid=0
+appraise func=BPRM_CHECK euid=0 appraise_type=imasig
+audit func=BPRM_CHECK euid=0
+
+measure func=MODULE_CHECK euid=0
+appraise func=MODULE_CHECK euid=0 appraise_type=imasig
+audit func=MODULE_CHECK euid=0
+
+measure func=FIRMWARE_CHECK euid=0
+appraise func=FIRMWARE_CHECK euid=0 appraise_type=imasig
+audit func=FIRMWARE_CHECK euid=0

--- a/recipes-support/ima-policy/ima-policy_0.1.bb
+++ b/recipes-support/ima-policy/ima-policy_0.1.bb
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2017 Wind River Systems Inc.
+#
+
+DESCRIPTION = "The default external IMA policy"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690 \
+                    file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+SRC_URI = " \
+	   file://ima_policy.default \
+          "
+
+do_install() {
+    install -d "${D}${sysconfdir}"
+    install -m 0400 "${WORKDIR}/ima_policy.default" \
+        "${D}${sysconfdir}"
+}
+
+CONFFILES_${PN} = "${sysconfdir}"
+
+FILES_${PN} = "${sysconfdir}"

--- a/recipes-support/key-store/key-store_0.1.bb
+++ b/recipes-support/key-store/key-store_0.1.bb
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2017 Wind River Systems, Inc.
+#
+
+DESCRIPTION = "User key store for key installation"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690 \
+                    file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+inherit user-key-store
+
+PACKAGES =+ " \
+             ${PN}-ima-pubkey \
+             ${PN}-ima-privkey \
+            "
+
+KEY_DIR = "/etc/keys"
+
+# For IMA appraise
+IMA_PRIV_KEY = "${KEY_DIR}/privkey_evm.pem"
+IMA_PUB_KEY = "${KEY_DIR}/pubkey_evm.pem"
+
+FILES_${PN}-ima-pubkey = "${IMA_PUB_KEY}"
+CONFFILES_${PN}-ima-pubkey = "${IMA_PUB_KEY}"
+FILES_${PN}-ima-privkey = "${IMA_PRIV_KEY}"
+CONFFILES_${PN}-ima-privkey = "${IMA_PRIV_KEY}"
+
+do_install() {
+    src_dir="${@uks_ima_keys_dir(d)}"
+
+    install -d "${D}${KEY_DIR}"
+    install -m 644 "$src_dir/ima_pubkey.pem" "${D}${IMA_PUB_KEY}"
+    install -m 400 "$src_dir/ima_privkey.pem" "${D}${IMA_PRIV_KEY}"
+}

--- a/templates/feature/ima/README
+++ b/templates/feature/ima/README
@@ -1,0 +1,138 @@
+Overview
+========
+
+The Linux IMA subsystem introduces hooks within the Linux kernel to support
+measuring the integrity of files that are loaded (including application code)
+before it is executed or mmap()ed to memory. The measured value (hash) is then
+registered in a log that can be consulted by administrators.
+
+To support proven integrity of the files, the IMA subsystem can interact with
+the TPM chip within the system to protect the registered hashes from tampering
+by a rogue administrator or application. The IMA subsystem, as already
+supported by the Linux kernel, supports reporting on the hashes of files and
+commands ran by privileged accounts (and more if you create your own
+measurement policies).
+
+In addition, IMA appraisal can even register the measured value as an extended
+attribute, and after subsequent measurement(s) validate this extended attribute
+against the measured value and refuse to load the file (or execute the
+application) if the hash does not match. In that case, the IMA subsystem allows
+files and applications to be loaded if the hashes match (and will save the
+updated hash if the file is modified) but refuse to load it if it doesn't. This
+provides some protection against offline tampering of the files.
+
+NOTE: Extended file system attribute is required for IMA appraise, but not
+all file systems support it. Typically, the pseudo file systems, such as
+sysfs, proc, tmpfs and ramfs, certain disk-based file systems, such as FAT,
+and network file systems, such as NFS, don't support extended attributes,
+meaning IMA appraise is not available with them.
+
+Dependency
+==========
+- meta-ima
+This layer provides the user space recipes for IMA.
+
+- meta-measured
+This layer provides the kernel configurations for IMA.
+
+The default external IMA policy
+===============================
+initramfs is a good place to run some IMA initializations, such as loading
+the IMA policy, as well as the public keys used to verify IMA signatures.
+
+The default external IMA policy enforces appraising all the executable, shared
+library, kernel modules and firmwares with the digital signature in the
+effective root identity (euid=0). Hence, the opportunity of loading the default
+external IMA policy occurs at the end of initramfs initializations, just before
+switch_root.
+
+Instead of running switch_root directly from initramfs, a statically linked
+switch_root from the real rootfs is called and it must be already signed
+properly. Otherwise, switch_root will fail to mount the real rootfs and kernel
+panic will happen due to this failure.
+
+The default external IMA policy is located at /etc/ima_policy.default in
+initramfs. If a custom external IMA policy file exists, the default external
+IMA policy file won't be used any more.
+
+The default external IMA policy applies the following rules:
+- Appraise the files for exec'd (the executables), files mmap'd for exec
+  (shared libraries), kernel modules and firmwares in effective root identity
+  (euid=0).
+- Deny to run the tampered executables, shared libraries, kernel modules and
+  firmwares.
+- Deny to run any executables, shared libraries, kernel modules and firmwares
+  in the filesystems without file extended attribute supported.
+- Deny to run the newly created executables, shared libraries, kernel modules
+  and firmwares (cause iversion support is not used on mounting filesystem).
+- Allow to run the updated executables, shared libraries, kernel modules and
+  firmwares during RPM installation.
+- Note the different behaviors when executing a script.
+  e.g, launching a python script with "./test.py" is allowed only when test.py
+  is signed, and launching a python script with "python test.py" is always
+  allowed as long as the python interpreter is signed.
+
+The custom external IMA policy
+==============================
+If the default external IMA policy cannot meet the protection requirement, it
+is allowed to define the custom external IMA policy.
+
+- Deploy the custom policy file to installer image
+
+- Create /opt/installer/sbin/config-installer.sh in installer image
+  Define the IMA_POLICY variable, pointint to the path of policy file.
+
+The custom external IMA policy file is located at /etc/ima_policy.
+
+The default IMA public key & private key
+========================================
+The default IMA public key & private key are installed to
+/etc/keys/pubkey_evm.pem and /etc/keys/privkey_evm.pem.
+
+The private key come in two flavors; one used by the installer to sign all
+regular files in rootfs and one used by signing the executable, shared
+library, kernel module and firmware during RPM update. Correspondingly,
+the public key is used to verify the IMA signature signed by the private key.
+
+The custom IMA public key & private key
+=======================================
+If the end user wants to use the public key & private key owned by self, it is
+allowed to define the use them during the installation.
+
+- Deploy the ima public key and private key to /opt/installer/files/
+
+- Create /opt/installer/sbin/config-installer.sh in installer image
+  Define the IMA_PUBKEY variable, pointing to the path of public key file.
+  Define the IMA_PRIVKEY variable, pointing to the path of private key file.
+
+Best practice
+=============
+The following best practices should be applied for the product.
+
+- Enable UEFI/MOK secure boot
+  UEFI/MOK secure boot can verify the integrity of initramfs, providing the
+  protection against tampering of the IMA policy files and IMA public keys
+  stored in initramfs.
+
+- Moderate measuring
+  Measuring the files owned by non-root user may introduce malicious attack.
+  Malicious user may create lots of files with different names or trigger
+  violation conditions to exhaust the persistent kernel memory used for
+  storing event logs to the runtime measurement list.
+
+- Use IMA digital signature to protect the executable
+  Using the digital signature scheme DIGSIG is safer than digest-based scheme.
+  Meanwhile, use "appraise_type=imasig" in your IMA policy to enforce running
+  this.
+
+- Use the measurement and audit rules together
+  The runtime measurement list is unable to track down the orders of change for
+  a file, e.g, a file content varies in order of such X -> Y -> X. However,
+  audit log can record these changes in the right order.
+
+Reference
+=========
+https://sourceforge.net/p/linux-ima/wiki/Home/
+template/uefi-secure-boot/README
+template/mok-secure-boot/README
+template/user-key-store-test/README

--- a/templates/feature/ima/template.conf
+++ b/templates/feature/ima/template.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (C) 2016 Wind River Systems, Inc.
+#
+
+IMA = "1"
+
+DISTRO_FEATURES_append += "ima"


### PR DESCRIPTION
The Linux IMA subsystem provides the integrity check for the files that
are loaded before it is executed or mmap()ed to memory.

In order to implement IMA in product level, both installation time and
runtime needs to be tuned.

- Installation time
  The installer needs to support labeling filesystems to provide the
  protections for the executable, shared libraries, kernel modules and
  firmwares. This part will be submitted to overc-installer.

- Runtime
  * Add "integrity_audit=1 ima_policy=tcb" in kernel commandline.
  * The default external policy and public key are loaded in initramfs.
  * Provide evmctl tool for IMA signing.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>