### PR TITLE
grub-efi: avoid repeatedly appending IMA boot options

### DIFF
--- a/recipes-bsp/grub/grub-efi_2.00.bbappend
+++ b/recipes-bsp/grub/grub-efi_2.00.bbappend
@@ -60,7 +60,7 @@ do_install_append_class-target() {
     fi
 
     # Enable integrity audit log and the default IMA rules if IMA is enabled.
-    [ x"${IMA}" = x"1" ] &&
+    [ x"${IMA}" = x"1" ] && ! grep -q "integrity_audit=1 ima_policy=tcb" $cfg &&
         sed -i 's/^\s*chainloader .*rootwait.*/& integrity_audit=1 ima_policy=tcb/' $cfg
 
     # Create a boot entry for Automatic Key Provision. This is required because


### PR DESCRIPTION
Signed-off-by: Lans Zhang <jia.zhang@windriver.com>