### PR TITLE
attr: build the statically linked setfattr

### DIFF
--- a/recipes-support/attr/attr_%.bbappend
+++ b/recipes-support/attr/attr_%.bbappend
@@ -1,0 +1,18 @@
+PACKAGES =+ "${PN}-setfattr.static"
+
+do_compile_append_class-target() {
+    ${CC} ${CFLAGS} ${LDFLAGS} -static \
+        -I${S}/include -L=${libdir} \
+        -DVERSION=\"${PV}\" -DPACKAGE=\"${PN}\" -DLOCALEDIR=\"${localedir}\" \
+        -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 \
+        -Wl,--start-group ${S}/setfattr/setfattr.c \
+        ${B}/libattr/.libs/libattr.a ${B}/libmisc/.libs/libmisc.a \
+        -Wl,--end-group -o ${B}/setfattr/setfattr.static
+}
+
+do_install_append_class-target() {
+    install -m 0755 ${B}/setfattr/setfattr.static \
+        ${D}${bindir}/setfattr.static
+}
+
+FILES_${PN}-setfattr.static += "${bindir}/setfattr.static"


### PR DESCRIPTION
setfattr will be used in RPM installation for setting the security.ima.
If we are updating attr package, the dynamically linked setfattr and
libattr cannot be launched. Therefore, introduce the statical version
to run %post hook for each RPM.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>