### PR TITLE
Clean up the variables used for feature decision

### DIFF
--- a/classes/user-key-store.bbclass
+++ b/classes/user-key-store.bbclass
@@ -5,6 +5,10 @@
 DEPENDS_append_class-target = " sbsigntool-native"
 USER_KEY_SHOW_VERBOSE = "1"
 
+UEFI_SB = '${@bb.utils.contains("DISTRO_FEATURES", "uefi-secure-boot", "1", "0", d)}'
+MOK_SB = '${@bb.utils.contains("DISTRO_FEATURES", "mok-secure-boot", "1", "0", d)}'
+IMA = '${@bb.utils.contains("DISTRO_FEATURES", "ima", "1", "0", d)}'
+
 def vprint(str, d):
     if d.getVar('USER_KEY_SHOW_VERBOSE', True) == '1':
         print(str)
@@ -343,8 +347,9 @@ def set_keys_dir(name, d):
 # Check and/or generate the user keys
 python do_check_user_keys_class-target () {
     vprint('Status before do_check_user_keys():', d)
-    vprint('  MOK_SB: ${MOK_SB}', d)
     vprint('  UEFI_SB: ${UEFI_SB}', d)
+    vprint('  MOK_SB: ${MOK_SB}', d)
+    vprint('  IMA: ${IMA}', d)
     vprint('  SIGNING_MODEL: ${SIGNING_MODEL}', d)
     vprint('  MOK_SB_KEYS_DIR: ${MOK_SB_KEYS_DIR}', d)
     vprint('  UEFI_SB_KEYS_DIR: ${UEFI_SB_KEYS_DIR}', d)

--- a/recipes-bsp/grub/grub-efi_2.00.bbappend
+++ b/recipes-bsp/grub/grub-efi_2.00.bbappend
@@ -63,7 +63,7 @@ do_install_append_class-target() {
     # disabled. This is because unseal operation will fail when any PCR is
     # extended due to updating the aggregate integrity value by the default
     # IMA rules.
-    [ x"${IMA}" = x"1" -a x"${STORAGE_ENCRYPTION}" != x"1" ] &&
+    [ x"${IMA}" = x"1" -a x"${@bb.utils.contains('DISTRO_FEATURES', 'storage-encryption', '1', '', d)}" != x"1" ] &&
         ! grep -q "ima_policy=tcb" $cfg &&
         sed -i 's/^\s*chainloader .*rootwait.*/& ima_policy=tcb/' $cfg
 

--- a/recipes-core/initrdscripts/initramfs-cube-builder.bbappend
+++ b/recipes-core/initrdscripts/initramfs-cube-builder.bbappend
@@ -6,13 +6,11 @@ SRC_URI += "\
 "
 
 do_install_append() {
-    if [ x"${STORAGE_ENCRYPTION}" = x"1" ]; then
+    [ x"${@bb.utils.contains('DISTRO_FEATURES', 'storage-encryption', '1', '', d)}" = x"1" ] &&
         install -m 0500 ${WORKDIR}/init.cryptfs ${D}
-    fi
 
-    if [ x"${IMA}" = x"1" ]; then
+    [ x"${@bb.utils.contains('DISTRO_FEATURES', 'ima', '1', '', d)}" = x"1" ] &&
         install -m 0500 ${WORKDIR}/init.ima ${D}
-    fi
 }
 
 FILES_${PN} += " \

--- a/templates/feature/ima/template.conf
+++ b/templates/feature/ima/template.conf
@@ -1,8 +1,7 @@
 #
-# Copyright (C) 2016 Wind River Systems, Inc.
+# Copyright (C) 2016-2017 Wind River Systems, Inc.
 #
 
-IMA = "1"
+DISTRO_FEATURES_append = " ima"
 
 INHERIT += "ima"
-DISTRO_FEATURES_append = " ima"

--- a/templates/feature/mok-secure-boot/template.conf
+++ b/templates/feature/mok-secure-boot/template.conf
@@ -1,8 +1,5 @@
 #
-# Copyright (C) 2016 Wind River Systems, Inc.
+# Copyright (C) 2016-2017 Wind River Systems, Inc.
 #
-
-# Indicate the feature of Mok secure boot is enabled
-MOK_SB = "1"
 
 DISTRO_FEATURES_append = " mok-secure-boot"

--- a/templates/feature/storage-encryption/template.conf
+++ b/templates/feature/storage-encryption/template.conf
@@ -1,8 +1,6 @@
 #
-# Copyright (C) 2016 Wind River Systems, Inc.
+# Copyright (C) 2016-2017 Wind River Systems, Inc.
 #
-
-STORAGE_ENCRYPTION = "1"
 
 DISTRO_FEATURES_append = " storage-encryption"
 

--- a/templates/feature/tpm/template.conf
+++ b/templates/feature/tpm/template.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 Wind River Systems, Inc.
+# Copyright (C) 2016-2017 Wind River Systems, Inc.
 #
 
 MACHINE_FEATURES_append = " tpm"

--- a/templates/feature/tpm2/template.conf
+++ b/templates/feature/tpm2/template.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2016 Wind River Systems, Inc.
+# Copyright (C) 2016-2017 Wind River Systems, Inc.
 #
 
 MACHINE_FEATURES_append = " tpm2"

--- a/templates/feature/uefi-secure-boot/template.conf
+++ b/templates/feature/uefi-secure-boot/template.conf
@@ -1,8 +1,6 @@
 #
-# Copyright (C) 2016 Wind River Systems, Inc.
+# Copyright (C) 2016-2017 Wind River Systems, Inc.
 #
-
-UEFI_SB = "1"
 
 DISTRO_FEATURES_append = " uefi-secure-boot"
 

--- a/templates/feature/user-key-store-test/template.conf
+++ b/templates/feature/user-key-store-test/template.conf
@@ -1,10 +1,8 @@
 #
-# Copyright (C) 2016 Wind River Systems, Inc.
+# Copyright (C) 2016-2017 Wind River Systems, Inc.
 #
 
 SIGNING_MODEL = "user"
-
-DISTRO_FEATURES_append = " user-key"
 
 USER_KEY_SHOW_VERBOSE = "1"
 


### PR DESCRIPTION
UEFI_SB, MOK_SB and IMA are moved into the interal of UKS, and
STORAGE_ENCRYPTION is dropped.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>