### PR TITLE
initramfs-cube-builder: fix do_install failure

### DIFF
--- a/recipes-bsp/grub/grub-efi_2.00.bbappend
+++ b/recipes-bsp/grub/grub-efi_2.00.bbappend
@@ -63,9 +63,10 @@ do_install_append_class-target() {
     # disabled. This is because unseal operation will fail when any PCR is
     # extended due to updating the aggregate integrity value by the default
     # IMA rules.
-    [ x"${IMA}" = x"1" -a x"${@bb.utils.contains('DISTRO_FEATURES', 'storage-encryption', '1', '', d)}" != x"1" ] &&
+    [ x"${IMA}" = x"1" -a x"${@bb.utils.contains('DISTRO_FEATURES', 'storage-encryption', '1', '0', d)}" != x"1" ] && {
         ! grep -q "ima_policy=tcb" $cfg &&
         sed -i 's/^\s*chainloader .*rootwait.*/& ima_policy=tcb/' $cfg
+    }
 
     # Create a boot entry for Automatic Certificate Provision. This is required because
     # certain hardware, e.g, Intel NUC5i3MYHE, doedn't support to display a

--- a/recipes-core/initrdscripts/initramfs-cube-builder.bbappend
+++ b/recipes-core/initrdscripts/initramfs-cube-builder.bbappend
@@ -6,11 +6,13 @@ SRC_URI += "\
 "
 
 do_install_append() {
-    [ x"${@bb.utils.contains('DISTRO_FEATURES', 'storage-encryption', '1', '', d)}" = x"1" ] &&
+    if [ x"${@bb.utils.contains('DISTRO_FEATURES', 'storage-encryption', '1', '0', d)}" = x"1" ]; then
         install -m 0500 ${WORKDIR}/init.cryptfs ${D}
+    fi
 
-    [ x"${@bb.utils.contains('DISTRO_FEATURES', 'ima', '1', '', d)}" = x"1" ] &&
+    if [ x"${@bb.utils.contains('DISTRO_FEATURES', 'ima', '1', '0', d)}" = x"1" ]; then
         install -m 0500 ${WORKDIR}/init.ima ${D}
+    fi
 }
 
 FILES_${PN} += " \


### PR DESCRIPTION
This syntax can cause bitbake failure:

[ test ] &&
    command

In order to work around this issue, use if .. then .. fi syntax.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>