### PR TITLE
shim: make an implementation change for auto loading the provisioning…

### DIFF
--- a/recipes-bsp/efitools/efitools/LockDown-disable-the-entrance-into-BIOS-setup-to-re-.patch
+++ b/recipes-bsp/efitools/efitools/LockDown-disable-the-entrance-into-BIOS-setup-to-re-.patch
@@ -1,0 +1,47 @@
+From e259aecc645c6dd4c194a64d607124cd5a714f9a Mon Sep 17 00:00:00 2001
+From: Lans Zhang <jia.zhang@windriver.com>
+Date: Wed, 15 Feb 2017 14:52:07 +0800
+Subject: [PATCH] LockDown: disable the entrance into BIOS setup to re-enable
+ secure boot
+
+In most cases, this step is not necessary.
+
+Signed-off-by: Lans Zhang <jia.zhang@windriver.com>
+---
+ LockDown.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/LockDown.c b/LockDown.c
+index 13c626f..fbde3f2 100644
+--- a/LockDown.c
++++ b/LockDown.c
+@@ -20,6 +20,11 @@ efi_main (EFI_HANDLE image, EFI_SYSTEM_TABLE *systab)
+ 	EFI_STATUS efi_status;
+ 	UINT8 SecureBoot, SetupMode;
+ 	UINTN DataSize = sizeof(SetupMode);
++	/* This controls whether it is required to enter into BIOS setup in
++	 * order to re-enable UEFI secure boot. This operation is unnecessary
++	 * in most cases.
++	 */
++	UINTN NeedSetAttempt = 0;
+ 
+ 	InitializeLib(image, systab);
+ 
+@@ -110,12 +115,12 @@ efi_main (EFI_HANDLE image, EFI_SYSTEM_TABLE *systab)
+ 	 * UEFI secure boot in BIOS setup.
+ 	 */
+ 	Print(L"Prepare to execute system warm reset after 3 seconds ...\n");
+-	if (!SecureBoot)
++	if (NeedSetAttempt && !SecureBoot)
+ 	        Print(L"After warm reset, enter to BIOS setup to enable UEFI Secure Boot.\n");
+ 
+ 	BS->Stall(3000000);
+ 
+-	if (!SecureBoot)
++	if (NeedSetAttempt && !SecureBoot)
+ 	        SETOSIndicationsAndReboot(EFI_OS_INDICATIONS_BOOT_TO_FW_UI);
+ 	else
+ 	        RT->ResetSystem(EfiResetWarm, EFI_SUCCESS, 0, NULL);
+-- 
+2.7.4
+

--- a/recipes-bsp/efitools/efitools_git.bb
+++ b/recipes-bsp/efitools/efitools_git.bb
@@ -14,7 +14,7 @@ SRC_URI_append = " \
 
 COMPATIBLE_HOST = '(i.86|x86_64).*-linux'
 
-inherit user-key-store
+inherit user-key-store deploy
 
 # The generated native binaries are used during native and target build
 DEPENDS_append = " ${BPN}-native gnu-efi openssl"
@@ -71,3 +71,10 @@ do_install_append() {
     install -d ${D}${EFI_BOOT_PATH}
     install -m 0755 ${D}${datadir}/efitools/efi/LockDown.efi ${D}${EFI_BOOT_PATH}
 }
+
+do_deploy() {
+    install -d ${DEPLOYDIR}
+
+    install -m 0600 ${D}${EFI_BOOT_PATH}/LockDown.efi "${DEPLOYDIR}"
+}
+addtask deploy after do_install before do_build

--- a/recipes-bsp/efitools/efitools_git.bb
+++ b/recipes-bsp/efitools/efitools_git.bb
@@ -9,6 +9,7 @@ SRC_URI_append = " \
     file://LockDown-show-the-error-message-with-3-sec-timeout.patch \
     file://Makefile-do-not-build-signed-efi-image.patch \
     file://Build-DBX-by-default.patch \
+    file://LockDown-disable-the-entrance-into-BIOS-setup-to-re-.patch \
 "
 
 COMPATIBLE_HOST = '(i.86|x86_64).*-linux'

--- a/recipes-bsp/grub/grub-efi_2.00.bbappend
+++ b/recipes-bsp/grub/grub-efi_2.00.bbappend
@@ -71,8 +71,10 @@ do_install_append_class-target() {
     # Create a boot entry for Automatic Certificate Provision. This is required because
     # certain hardware, e.g, Intel NUC5i3MYHE, doedn't support to display a
     # customized BIOS boot option used to launch LockDown.efi.
-    [ x"${UEFI_SB}" = x"1" ] && ! grep -q "Automatic Certificate Provision" $cfg &&
-        cat >> $cfg <<_EOF
+    # Note that shim loader supports to automatically launch LockDown.efi.
+    [ x"${UEFI_SB}" = x"1" ] && [ x"${MOK_SB}" != x"1" ] &&
+        ! grep -q "Automatic Certificate Provision" $cfg &&
+            cat >> $cfg <<_EOF
 
 menuentry 'Automatic Certificate Provision' {
     chainloader /EFI/BOOT/LockDown.efi

--- a/recipes-bsp/shim/shim/Always-run-LockDown.efi-if-not-in-secure-mode-to-pro.patch
+++ b/recipes-bsp/shim/shim/Always-run-LockDown.efi-if-not-in-secure-mode-to-pro.patch
@@ -1,0 +1,49 @@
+From 53c6d8cd5a0f914475e819e13d2c49f844cfc06c Mon Sep 17 00:00:00 2001
+From: Lans Zhang <jia.zhang@windriver.com>
+Date: Wed, 15 Feb 2017 13:35:49 +0800
+Subject: [PATCH] Always run LockDown.efi if not in secure mode to provision
+ MOK
+
+The LockDown.efi should always be run if the system is not running in
+secure mode because all the other pieces of the system expect to be
+running in secure mode if you are using the shim.
+
+If LockDown.efi is not found or secure boot was provisioned, grub
+will be executed.
+
+Signed-off-by: Jason Wessel <jason.wessel@windriver.com>
+Signed-off-by: Lans Zhang <jia.zhang@windriver.com>
+---
+ shim.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/shim.c b/shim.c
+index b5f1a2b..43779c5 100644
+--- a/shim.c
++++ b/shim.c
+@@ -61,6 +61,8 @@
+ 
+ #define OID_EKU_MODSIGN "1.3.6.1.4.1.2312.16.1.2"
+ 
++EFI_STATUS execute(EFI_HANDLE image, CHAR16 *name);
++
+ static EFI_SYSTEM_TABLE *systab;
+ static EFI_HANDLE image_handle;
+ static EFI_STATUS (EFIAPI *entry_point) (EFI_HANDLE image_handle, EFI_SYSTEM_TABLE *system_table);
+@@ -2695,6 +2697,13 @@ efi_main (EFI_HANDLE passed_image_handle, EFI_SYSTEM_TABLE *passed_systab)
+ 	debug_hook();
+ 
+ 	/*
++	 * If not in secure mode try to run LockDown.efi to get into
++	 * secure mode
++	 */
++	if (!secure_mode())
++		execute(image_handle, L"\\LockDown.efi");
++
++	/*
+ 	 * Measure the MOK variables
+ 	 */
+ 	efi_status = measure_mok();
+-- 
+2.7.4
+

--- a/recipes-bsp/shim/shim_git.bb
+++ b/recipes-bsp/shim/shim_git.bb
@@ -77,8 +77,8 @@ addtask prepare_signing_keys after do_check_user_keys before do_compile
 
 python do_sign() {
     shim_sb_sign('${S}/shim${EFI_ARCH}.efi', '${B}/shim${EFI_ARCH}.efi.signed', d)
-    shim_sb_sign('${S}/mm${EFI_ARCH}.efi', '${B}/mm${EFI_ARCH}.efi.signed', d)
-    shim_sb_sign('${S}/fb${EFI_ARCH}.efi', '${B}/fb${EFI_ARCH}.efi.signed', d)
+    sb_sign('${S}/mm${EFI_ARCH}.efi', '${B}/mm${EFI_ARCH}.efi.signed', d)
+    sb_sign('${S}/fb${EFI_ARCH}.efi', '${B}/fb${EFI_ARCH}.efi.signed', d)
 }
 addtask sign after do_compile before do_install
 

--- a/recipes-bsp/shim/shim_git.bb
+++ b/recipes-bsp/shim/shim_git.bb
@@ -30,6 +30,7 @@ SRC_URI = " \
         file://Fix-the-world-build-failure-due-to-the-missing-rule-.patch \
         file://Don-t-enforce-to-use-gnu89-standard.patch \
 	file://Makefile-do-not-sign-the-efi-file.patch \
+	file://Always-run-LockDown.efi-if-not-in-secure-mode-to-pro.patch \
 "
 SRCREV = "431d893b41c53f6a022031ca0cc66fd298e0e472"
 PV = "0.9+git${SRCPV}"


### PR DESCRIPTION
… key

A secure target should only boot in secure mode.

This means we should force the key provisioning as a part of the boot
process if the target is not already provisioned.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>
Signed-off-by: Lans Zhang <jia.zhang@windriver.com>