### PR TITLE
IMA: fix RPM installation failure

### DIFF
--- a/classes/ima.bbclass
+++ b/classes/ima.bbclass
@@ -52,7 +52,7 @@ python package_ima_hook() {
 
             with open(_ + '.sig', 'r') as f:
                 s = base64.b64encode(f.read()) + ':'
-                sig_list.append(s + os.sep + os.path.relpath(sh_name, pkgdestpkg))
+                sig_list.append(s + os.sep + os.path.relpath(_, pkgdestpkg))
 
             os.remove(_ + '.sig')
 


### PR DESCRIPTION
If the path of installed file in RPM contains a character requiring
being escaped in shell, e.g, a space, the installation will fail.

The signature list should not use the escaped filename. Otherwise, the
file path in the signature list will be corrupted and points to a
nonexistent place.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>