### PR TITLE
cryptfs-tpm2: add tpm2.0-tools to RDEPEND

### DIFF
--- a/recipes-support/key-store/key-store_0.1.bb
+++ b/recipes-support/key-store/key-store_0.1.bb
@@ -22,6 +22,7 @@ PACKAGES =+ " \
 RPM_KEY_DIR = "${sysconfdir}/pki/rpm-gpg"
 FILES_${PN}-rpm-pubkey = "${RPM_KEY_DIR}/RPM-GPG-KEY-*"
 CONFFILES_${PN}-rpm-pubkey = "${RPM_KEY_DIR}/RPM-GPG-KEY-*"
+RDEPENDS_${PN}-rpm-pubkey += "rpm"
 
 # Note IMA private key is not available if user key signing model used.
 PACKAGES_DYNAMIC += "${PN}-ima-privkey"

--- a/recipes-tpm/cryptfs-tpm2/cryptfs-tpm2_git.bb
+++ b/recipes-tpm/cryptfs-tpm2/cryptfs-tpm2_git.bb
@@ -19,7 +19,7 @@ SRCREV = "7234a763bf5c2f1821f168d8f50b3ed3f098d911"
 PV = "0.4.2+git${SRCPV}"
 
 DEPENDS += "tpm2.0-tss"
-RDEPENDS_${PN} += "libtss2 libtctisocket"
+RDEPENDS_${PN} += "libtss2 libtctisocket tpm2.0-tools"
 
 PARALLEL_MAKE = ""
 


### PR DESCRIPTION
luks-setup.sh in cryptfs-tpm2 now requires tpm2_takeownership command to
clear TPM 2.0 chip during initialization.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>