### PR TITLE
sign-rpm: fix build failure due to rpm signing

### DIFF
--- a/recipes-core/meta/signing-keys.bbappend
+++ b/recipes-core/meta/signing-keys.bbappend
@@ -27,15 +27,11 @@ python do_import_keys () {
         if check_gpg_key(d, d.getVar("RPM_GPG_NAME", True)) is True:
             return
 
-        if d.getVar("RPM_GPG_PRIKEY", True):
+        if d.getVar("RPM_GPG_PRIVKEY", True):
             # Import private key of the rpm signing key
-            import_gpg_key(d, d.getVar('RPM_GPG_PRIKEY', True))
+            import_gpg_key(d, d.getVar('RPM_GPG_PRIVKEY', True))
 }
 
 # sign_rpm depends on do_export_public_keys in oe-core,
 # so keys have been already imported when running sign_rpm
 addtask do_import_keys before do_export_public_keys
-
-# If RDEPENDS is not set to empty, glibc is added to RDEPENDS by default,
-# so that glibc will fail at signing rpm.
-RDEPENDS_${PN} = ""


### PR DESCRIPTION
signing-key itself is only used for importing/exporting pubkey on build
host, so it is not required to build it for target.

In addition, fix a typo for the name of private key.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>