### PR TITLE
signing-keys: fix rpm signing failure if both gpg and gpg2 installed

### DIFF
--- a/recipes-core/meta/signing-keys.bbappend
+++ b/recipes-core/meta/signing-keys.bbappend
@@ -3,16 +3,18 @@
 def import_gpg_key(d, path):
     import bb
     gpg_bin = d.getVar('GPG_BIN', True) or \
+              bb.utils.which(os.getenv('PATH'), "gpg2") or \
               bb.utils.which(os.getenv('PATH'), "gpg")
     cmd = '%s --import %s' % (gpg_bin, path)
     status, output = oe.utils.getstatusoutput(cmd)
     if status:
-        raise bb.build.FuncFailed('Failed to import gpg key (%s): %s' %
+        raise bb.build.FuncFailed('Failed to import gpg key (%s): %s' % \
                                   (path, output))
 
 def check_gpg_key(d, keyid):
     import bb
     gpg_bin = d.getVar('GPG_BIN', True) or \
+              bb.utils.which(os.getenv('PATH'), "gpg2") or \
               bb.utils.which(os.getenv('PATH'), "gpg")
     cmd = '%s --list-keys -a "%s"' % (gpg_bin, keyid)
     status, output = oe.utils.getstatusoutput(cmd)


### PR DESCRIPTION
rpm5 always searches gpg2 in higher priority to sign RPM. Hence, if the
signing-keys imports the key with gpg, rpm5 signing will fail for sure
because gpg2 cannot find out the keyring employed by gpg.

This issue only happens if both gpg and gpg2 are installed on a build host.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>