### PR TITLE
tpm: improve tpm2.0-tss service to support bsp actions-s500

### DIFF
--- a/recipes-tpm/tpm2.0-tss/tpm2.0-tss/tpm2.0-tss.service
+++ b/recipes-tpm/tpm2.0-tss/tpm2.0-tss/tpm2.0-tss.service
@@ -2,11 +2,11 @@
 Description=TPM 2.0 TCG Software Stack service
 After=syslog.target network.target
 ConditionPathExists=/dev/tpm0
-ConditionPathExistsGlob=/sys/class/tpm/tpm0/device/description
+ConditionPathExistsGlob=/sys/class/tpm/tpm0/@TPM_DESCRIPTION@
 
 [Service]
 Type=simple
-ExecStartPre=/bin/sh -c "fgrep 'TPM 2.0' /sys/class/tpm/tpm0/device/description"
+ExecStartPre=/bin/sh -c "fgrep '@FAMILY_MAJOR@' /sys/class/tpm/tpm0/@TPM_DESCRIPTION@"
 ExecStart=/usr/sbin/resourcemgr
 
 TimeoutSec=30s

--- a/recipes-tpm/tpm2.0-tss/tpm2.0-tss_git.bbappend
+++ b/recipes-tpm/tpm2.0-tss/tpm2.0-tss_git.bbappend
@@ -15,9 +15,18 @@ RRECOMMENDS_${PN} += "\
 	kernel-module-tpm-tis \
 "
 
+TPM_DESCRIPTION_x86 = 'device/description'
+FAMILY_MAJOR_x86 = 'TPM 2.0'
+TPM_DESCRIPTION_x86-64 = 'device/description'
+FAMILY_MAJOR_x86-64 = 'TPM 2.0'
+TPM_DESCRIPTION_actions-s500 = 'family_major'
+FAMILY_MAJOR_actions-s500 = '2'
+
 do_install_append () {
     install -d ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/tpm2.0-tss.service ${D}${systemd_unitdir}/system
+    sed -i 's:@TPM_DESCRIPTION@:${TPM_DESCRIPTION}:' ${D}${systemd_unitdir}/system/tpm2.0-tss.service
+    sed -i 's:@FAMILY_MAJOR@:${FAMILY_MAJOR}:' ${D}${systemd_unitdir}/system/tpm2.0-tss.service
 }
 
 SYSTEMD_PACKAGES = "resourcemgr"


### PR DESCRIPTION
So far, we support TPM2.0 service on x86 platform and start TPM2.0
service if there is a file named description in
/sys/class/tpm/tpmX/device. But on arm platform, bsp actions-s500,
this description file is in /sys/class/tpm/tpmX/. So, modify code
to support the 2 platforms.

Signed-off-by: Meng Li <Meng.Li@windriver.com>