### PR TITLE
tpm: improve tcsd service to support bsp actions-s500

### DIFF
--- a/recipes-tpm/trousers/files/tcsd.service
+++ b/recipes-tpm/trousers/files/tcsd.service
@@ -4,11 +4,11 @@ After=syslog.target network.target
 ConditionPathExists=|/dev/tpm0
 ConditionPathExists=|/udev/tpm0
 ConditionPathExists=|/dev/tpm
-ConditionPathExistsGlob=/sys/class/*/tpm0/device/caps
+ConditionPathExistsGlob=/sys/class/*/tpm0/@TPM_CAPS@
 
 [Service]
 Type=forking
-ExecStartPre=/bin/sh -c "fgrep 'TCG version: 1.2' /sys/class/*/tpm0/device/caps"
+ExecStartPre=/bin/sh -c "fgrep '@FAMILY_MAJOR@' /sys/class/*/tpm0/@TPM_CAPS@"
 ExecStart=/usr/sbin/tcsd
 
 TimeoutSec=30s

--- a/recipes-tpm/trousers/trousers_0.3.13.bbappend
+++ b/recipes-tpm/trousers/trousers_0.3.13.bbappend
@@ -13,10 +13,19 @@ SRC_URI += "\
 SYSTEMD_SERVICE_${PN} = "tcsd.service"
 SYSTEMD_AUTO_ENABLE = "enable"
 
+TPM_CAPS_x86 = 'device/caps'
+FAMILY_MAJOR_x86 = 'TCG version: 1.2'
+TPM_CAPS_x86-64 = 'device/caps'
+FAMILY_MAJOR_x86-64 = 'TCG version: 1.2'
+TPM_CAPS_actions-s500 = 'family_major'
+FAMILY_MAJOR_actions-s500 = '1'
+
 do_install_append () {
     install -m 0600 ${WORKDIR}/tcsd.conf ${D}${sysconfdir}
     chown tss:tss ${D}${sysconfdir}/tcsd.conf
 
     install -d ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/tcsd.service ${D}${systemd_unitdir}/system
+    sed -i 's:@TPM_CAPS@:${TPM_CAPS}:' ${D}${systemd_unitdir}/system/tcsd.service
+    sed -i 's:@FAMILY_MAJOR@:${FAMILY_MAJOR}:' ${D}${systemd_unitdir}/system/tcsd.service
 }


### PR DESCRIPTION
So far, we support tcsd service on x86 platform and start tscd
service if there is a file named caps in /sys/class/tpm/tpmX/device.
But on arm platform, bsp actions-s500, this description file is in
in /sys/class/tpm/tpmX/. So, modify code to support the 2 platforms.

Signed-off-by: Meng Li <Meng.Li@windriver.com>