### PR TITLE
mok-secure-boot: setup global GRUB_IMAGE

### DIFF
--- a/templates/feature/efi-secure-boot/template.conf
+++ b/templates/feature/efi-secure-boot/template.conf
@@ -8,3 +8,5 @@ DISTRO_FEATURES_append = " efi-secure-boot"
 KERNEL_FEATURES_append_x86 = " cfg/efi.scc"
 KERNEL_FEATURES_append_x86-64 = " cfg/efi.scc"
 
+# Setup GRUB_IMAGE for UEFI secure boot
+GRUB_IMAGE = '${@bb.utils.contains("TARGET_ARCH", "x86_64", "grubx64.efi", "grubia32.efi", d)}'


### PR DESCRIPTION
GRUB_IMAGE has to been renamed to grub${EFI_ARCH}.efi if MOK Secure
Boot / SELoader is configured. This setting is usually working within
the recipe scope but certain bbclass is not affected and eventually
still uses the wrong naming scheme.

In order to fix this issue, place GRUB_IMAGE into global naming space
and all references to GRUB_IMAGE would sense it.

Signed-off-by: Wenzong Fan <wenzong.fan@windriver.com>